### PR TITLE
Less requests (and rename “list” to ”status”)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ jobs:
           # Hint: Set these on an organisation level and override in repos only when necessary
           jira-domain: ${{ vars.JIRA_DOMAIN }}
           jira-user: ${{ secrets.JIRA_USER }}
+          # Create one at: https://id.atlassian.com/manage-profile/security/api-tokens
+          # Note that user whose API token is used, will “touch” all of
+          # the issues, so it’s best to create a dedicated user for
+          # this sort of things.
           jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
           jira-list-pr-draft: ${{ vars.JIRA_LIST_PR_DRAFT }}
           jira-list-pr-ready: ${{ vars.JIRA_LIST_PR_READY }}

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ jobs:
           # the issues, so it’s best to create a dedicated user for
           # this sort of things.
           jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
-          jira-list-pr-draft: ${{ vars.JIRA_LIST_PR_DRAFT }}
-          jira-list-pr-ready: ${{ vars.JIRA_LIST_PR_READY }}
-          jira-list-pr-merged: ${{ vars.JIRA_LIST_PR_MERGED }}
+          jira-status-pr-draft: ${{ vars.JIRA_STATUS_PR_DRAFT }}
+          jira-status-pr-ready: ${{ vars.JIRA_STATUS_PR_READY }}
+          jira-status-pr-merged: ${{ vars.JIRA_STATUS_PR_MERGED }}
 ```
 
 ## Debugging

--- a/action.yml
+++ b/action.yml
@@ -18,16 +18,16 @@ inputs:
     description: 'Email address of the Jira user'
     required: true
   jira-api-token:
-    description: 'Jira API key, get it on <https://id.atlassian.com/manage-profile/security/api-tokens>'
+    description: 'Jira API key, get it on <https://id.atlassian.com/manage-profile/security/api-tokens>. Note that user whose API token is used, will “touch” all of the issues, so it’s best to create a dedicated user for this sort of things.'
     required: true
-  jira-list-pr-draft:
-    description: 'Name of the column to move tickets to when PR is in draft'
+  jira-status-pr-draft:
+    description: 'Name of the status to transition issue to when PR is in draft'
     required: false
-  jira-list-pr-ready:
-    description: 'Name of the column to move tickets to when PR is ready to review'
+  jira-status-pr-ready:
+    description: 'Name of the status to transition issue to when PR is ready to review'
     required: false
-  jira-list-pr-merged:
-    description: 'Name of the column to move tickets to when PR is merged'
+  jira-status-pr-merged:
+    description: 'Name of the status to transition issue to when PR is merged'
     required: false
 runs:
   using: node20

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,6 @@ inputs:
   github-token:
     description: 'Github token, https://docs.github.com/en/actions/reference/authentication-in-a-workflow'
     required: true
-  github-require-keyword-prefix:
-    description: 'When true match only URLs prefixed with “Closes” etc just like https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword. Defaults to true.'
-    required: false
   jira-domain:
     description: 'Jira domain, e.g. example.atlassian.net'
     required: true

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42341,9 +42341,9 @@ const githubRequireKeywordPrefix =
 const jiraDomain = core.getInput('jira-domain', { required: true })
 const jiraUser = core.getInput('jira-user', { required: true })
 const jiraApiToken = core.getInput('jira-api-token', { required: true })
-const jiraListPrDraft = core.getInput('jira-list-pr-draft')
-const jiraListPrReady = core.getInput('jira-list-pr-ready')
-const jiraListPrMerged = core.getInput('jira-list-pr-merged')
+const jiraStatusPrDraft = core.getInput('jira-status-pr-draft')
+const jiraStatusPrReady = core.getInput('jira-status-pr-ready')
+const jiraStatusPrMerged = core.getInput('jira-status-pr-merged')
 
 const jiraApi = lib_axios.create({
   // https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/
@@ -42573,28 +42573,28 @@ async function main() {
     await assignPrToIssues(issueIds)
 
     if (pr.state === 'open' && isDraft) {
-      if (!jiraListPrDraft) {
+      if (!jiraStatusPrDraft) {
         console.log(
           'No draft PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraListPrDraft)
+        await transitionIssues(issueIds, jiraStatusPrDraft)
       }
     } else if (pr.state === 'open' && !isDraft) {
-      if (!jiraListPrReady) {
+      if (!jiraStatusPrReady) {
         console.log(
           'No ready PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraListPrReady)
+        await transitionIssues(issueIds, jiraStatusPrReady)
       }
     } else if (pr.state === 'closed') {
-      if (!jiraListPrMerged) {
+      if (!jiraStatusPrMerged) {
         console.log(
           'No merged PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraListPrMerged)
+        await transitionIssues(issueIds, jiraStatusPrMerged)
       }
     } else {
       console.log(

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42323,8 +42323,10 @@ var github_namespaceObject = /*#__PURE__*/__nccwpck_require__.t(github, 2);
 // Use these for local debugging.
 // You will also need `mock-inputs.json` with input values.
 //
-// import * as core from './mock.mjs'
-// import * as github from './mock.mjs'
+// import * as mock from './mock.mjs'
+//
+// const core = mock
+// const github = mock
 
 const {
   context,
@@ -42371,22 +42373,28 @@ function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
-async function getIssueStatusName(issueId) {
-  const response = await jiraApi.get(`issue/${encodeURIComponent(issueId)}`)
-  const currentStatusName = response.data.fields.status.name
-  return normaliseStatusName(currentStatusName)
-}
+async function getIssue(issueId) {
+  const response = await jiraApi.get(`issue/${encodeURIComponent(issueId)}`, {
+    params: {
+      fields: 'status',
+      expand: 'transitions',
+    },
+  })
+  const {
+    data: {
+      fields: { status },
+      transitions,
+    },
+  } = response
 
-async function getIssueTransitionIds(issueId) {
-  const response = await jiraApi.get(
-    `issue/${encodeURIComponent(issueId)}/transitions`
-  )
-  const { transitions } = response.data
-  return new Map(
-    transitions
-      .filter((t) => t.isAvailable)
-      .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
-  )
+  return {
+    currentStatusName: normaliseStatusName(status.name),
+    availableTransitions: new Map(
+      transitions
+        .filter((t) => t.isAvailable)
+        .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
+    ),
+  }
 }
 
 const octokit = github.getOctokit(githubToken)
@@ -42432,13 +42440,7 @@ async function main() {
           'No draft PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssue(issueIds, jiraListPrDraft)
-        console.log(
-          'Transitioned',
-          issueIds.length,
-          'issue(s) to',
-          jiraListPrDraft
-        )
+        await transitionIssues(issueIds, jiraListPrDraft)
       }
     } else if (pr.state === 'open' && !isDraft) {
       if (!jiraListPrReady) {
@@ -42446,13 +42448,7 @@ async function main() {
           'No ready PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssue(issueIds, jiraListPrReady)
-        console.log(
-          'Transitioned',
-          issueIds.length,
-          'issue(s) to',
-          jiraListPrReady
-        )
+        await transitionIssues(issueIds, jiraListPrReady)
       }
     } else if (pr.state === 'closed') {
       if (!jiraListPrMerged) {
@@ -42460,13 +42456,7 @@ async function main() {
           'No merged PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssue(issueIds, jiraListPrMerged)
-        console.log(
-          'Transitioned',
-          issueIds.length,
-          'issue(s) to',
-          jiraListPrMerged
-        )
+        await transitionIssues(issueIds, jiraListPrMerged)
       }
     } else {
       console.log(
@@ -42569,22 +42559,26 @@ async function assignPrToIssues(issueIds, pr) {
   console.log('Assigned PR', `#${pr.number}`, 'to', issueIds.length, 'issue(s)')
 }
 
-async function transitionIssue(issueIds, newStatusName) {
+async function transitionIssues(issueIds, newStatusName) {
   return Promise.all(
     issueIds.map(async (issueId) => {
-      console.log('Transitioning issue', issueId, 'to', newStatusName)
-
       const newStatusNameNormalised = normaliseStatusName(newStatusName)
 
-      const currentStatusName = await getIssueStatusName(issueId)
+      const { currentStatusName, availableTransitions } =
+        await getIssue(issueId)
 
-      if (currentStatusName !== newStatusNameNormalised) {
-        const transitionIds = await getIssueTransitionIds(issueId)
-
-        const newStatusId = transitionIds.get(newStatusNameNormalised)
+      if (currentStatusName === newStatusNameNormalised) {
+        console.log(
+          'Did not transition',
+          issueId,
+          '— already in',
+          newStatusName
+        )
+      } else {
+        const newStatusId = availableTransitions.get(newStatusNameNormalised)
         if (newStatusId == null) {
           throw new Error(
-            `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(transitionIds.keys()).join(', ')}`
+            `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(availableTransitions.keys()).join(', ')}`
           )
         }
 
@@ -42593,6 +42587,8 @@ async function transitionIssue(issueIds, newStatusName) {
             id: newStatusId,
           },
         })
+
+        console.log('Transitioned', issueId, 'to', newStatusName)
       }
     })
   )

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42367,6 +42367,16 @@ jiraApi.interceptors.response.use(
   }
 )
 
+function normaliseStatusName(name) {
+  return name.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+async function getIssueStatusName(issueId) {
+  const response = await jiraApi.get(`issue/${encodeURIComponent(issueId)}`)
+  const currentStatusName = response.data.fields.status.name
+  return normaliseStatusName(currentStatusName)
+}
+
 async function getIssueTransitionIds(issueId) {
   const response = await jiraApi.get(
     `issue/${encodeURIComponent(issueId)}/transitions`
@@ -42375,7 +42385,7 @@ async function getIssueTransitionIds(issueId) {
   return new Map(
     transitions
       .filter((t) => t.isAvailable)
-      .map((t) => [t.name.toLowerCase(), Number.parseInt(t.id, 10)])
+      .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
   )
 }
 
@@ -42419,7 +42429,7 @@ async function main() {
     if (pr.state === 'open' && isDraft) {
       if (!jiraListPrDraft) {
         console.log(
-          'No draft PR list name provided, skipping transitioning issues'
+          'No draft PR status name provided, skipping transitioning issues'
         )
       } else {
         await transitionIssue(issueIds, jiraListPrDraft)
@@ -42433,7 +42443,7 @@ async function main() {
     } else if (pr.state === 'open' && !isDraft) {
       if (!jiraListPrReady) {
         console.log(
-          'No ready PR list name provided, skipping transitioning issues'
+          'No ready PR status name provided, skipping transitioning issues'
         )
       } else {
         await transitionIssue(issueIds, jiraListPrReady)
@@ -42447,7 +42457,7 @@ async function main() {
     } else if (pr.state === 'closed') {
       if (!jiraListPrMerged) {
         console.log(
-          'No merged PR list name provided, skipping transitioning issues'
+          'No merged PR status name provided, skipping transitioning issues'
         )
       } else {
         await transitionIssue(issueIds, jiraListPrMerged)
@@ -42559,25 +42569,31 @@ async function assignPrToIssues(issueIds, pr) {
   console.log('Assigned PR', `#${pr.number}`, 'to', issueIds.length, 'issue(s)')
 }
 
-async function transitionIssue(issueIds, listName) {
+async function transitionIssue(issueIds, newStatusName) {
   return Promise.all(
     issueIds.map(async (issueId) => {
-      console.log('Transitioned issue', issueId, 'to', listName)
+      console.log('Transitioning issue', issueId, 'to', newStatusName)
 
-      const transitionIds = await getIssueTransitionIds(issueId)
+      const newStatusNameNormalised = normaliseStatusName(newStatusName)
 
-      const listId = transitionIds.get(listName.toLowerCase())
-      if (listId == null) {
-        throw new Error(
-          `List name ${listName} not found in JIRA. Available lists: ${Array.from(transitionIds.keys()).join(', ')}`
-        )
+      const currentStatusName = await getIssueStatusName(issueId)
+
+      if (currentStatusName !== newStatusNameNormalised) {
+        const transitionIds = await getIssueTransitionIds(issueId)
+
+        const newStatusId = transitionIds.get(newStatusNameNormalised)
+        if (newStatusId == null) {
+          throw new Error(
+            `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(transitionIds.keys()).join(', ')}`
+          )
+        }
+
+        await jiraApi.post(`issue/${encodeURIComponent(issueId)}/transitions`, {
+          transition: {
+            id: newStatusId,
+          },
+        })
       }
-
-      return jiraApi.post(`issue/${encodeURIComponent(issueId)}/transitions`, {
-        transition: {
-          id: listId,
-        },
-      })
     })
   )
 }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42373,28 +42373,25 @@ function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
-async function getIssue(issueId) {
-  const response = await jiraApi.get(`issue/${encodeURIComponent(issueId)}`, {
+async function getIssues(issuesIds) {
+  const response = await jiraApi.get('search', {
     params: {
+      maxResults: 100,
+      jql: `id in (${issuesIds.join(',')})`,
       fields: 'status',
       expand: 'transitions',
     },
   })
-  const {
-    data: {
-      fields: { status },
-      transitions,
-    },
-  } = response
 
-  return {
-    currentStatusName: normaliseStatusName(status.name),
+  return response.data.issues.map((jiraIssueData) => ({
+    issueKey: jiraIssueData.key,
+    currentStatusName: normaliseStatusName(jiraIssueData.fields.status.name),
     availableTransitions: new Map(
-      transitions
+      jiraIssueData.transitions
         .filter((t) => t.isAvailable)
         .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
     ),
-  }
+  }))
 }
 
 const octokit = github.getOctokit(githubToken)
@@ -42496,7 +42493,11 @@ function matchIssueIds(text) {
   const keywordsRegExp = githubRequireKeywordPrefix
     ? `(?:${keywords.join('|')})\\s+`
     : ''
-  const urlRegExp = `https://${jiraDomain}/browse/([A-Z]+-\\d+)`
+  // Warning:
+  // It’s extremely important for this regexp to match only simple
+  // jira keys as extracted keys will be used in JQL queries.
+  const issueIdRegExp = '[A-Z]+-[0-9]+'
+  const urlRegExp = `https://${jiraDomain}/browse/(${issueIdRegExp})`
   const closesRegExp = `${keywordsRegExp}${urlRegExp}(?:\\s*,\\s*${urlRegExp})*`
 
   // Find all “Closes URL, URL…”
@@ -42559,38 +42560,42 @@ async function assignPrToIssues(issueIds, pr) {
   console.log('Assigned PR', `#${pr.number}`, 'to', issueIds.length, 'issue(s)')
 }
 
-async function transitionIssues(issueIds, newStatusName) {
+async function transitionIssues(issuesIds, newStatusName) {
+  const newStatusNameNormalised = normaliseStatusName(newStatusName)
+
+  const issuesData = await getIssues(issuesIds)
+
   return Promise.all(
-    issueIds.map(async (issueId) => {
-      const newStatusNameNormalised = normaliseStatusName(newStatusName)
-
-      const { currentStatusName, availableTransitions } =
-        await getIssue(issueId)
-
-      if (currentStatusName === newStatusNameNormalised) {
-        console.log(
-          'Did not transition',
-          issueId,
-          '— already in',
-          newStatusName
-        )
-      } else {
-        const newStatusId = availableTransitions.get(newStatusNameNormalised)
-        if (newStatusId == null) {
-          throw new Error(
-            `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(availableTransitions.keys()).join(', ')}`
+    issuesData.map(
+      async ({ issueKey, currentStatusName, availableTransitions }) => {
+        if (currentStatusName === newStatusNameNormalised) {
+          console.log(
+            'Did not transition',
+            issueKey,
+            '— already in',
+            newStatusName
           )
+        } else {
+          const newStatusId = availableTransitions.get(newStatusNameNormalised)
+          if (newStatusId == null) {
+            throw new Error(
+              `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(availableTransitions.keys()).join(', ')}`
+            )
+          }
+
+          await jiraApi.post(
+            `issue/${encodeURIComponent(issueKey)}/transitions`,
+            {
+              transition: {
+                id: newStatusId,
+              },
+            }
+          )
+
+          console.log('Transitioned', issueKey, 'to', newStatusName)
         }
-
-        await jiraApi.post(`issue/${encodeURIComponent(issueId)}/transitions`, {
-          transition: {
-            id: newStatusId,
-          },
-        })
-
-        console.log('Transitioned', issueId, 'to', newStatusName)
       }
-    })
+    )
   )
 }
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42338,16 +42338,19 @@ const githubToken = core.getInput('github-token')
 const githubRequireKeywordPrefix =
   core.getInput('github-require-keyword-prefix') ?? true
 
-const jiraDomain = core.getInput('jira-domain', { required: true })
+const jiraDomainInput = core.getInput('jira-domain', { required: true })
 const jiraUser = core.getInput('jira-user', { required: true })
 const jiraApiToken = core.getInput('jira-api-token', { required: true })
 const jiraStatusPrDraft = core.getInput('jira-status-pr-draft')
 const jiraStatusPrReady = core.getInput('jira-status-pr-ready')
 const jiraStatusPrMerged = core.getInput('jira-status-pr-merged')
 
+// https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/
+const jiraApiBaseUrl = new URL(`https://${jiraDomainInput}`)
+jiraApiBaseUrl.pathname = '/rest/api/2'
+
 const jiraApi = lib_axios.create({
-  // https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/
-  baseURL: `https://${jiraDomain}/rest/api/2`,
+  baseURL: jiraApiBaseUrl.toString(),
   headers: {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
@@ -42399,18 +42402,9 @@ async function getIssues(issuesKeys) {
   }))
 }
 
-async function extractResolvedIssueKeys(prBody, comments) {
-  console.log('Searching for issue ids')
+function extractResolvedIssueKeys(prBody, comments) {
+  const text = [prBody, ...comments.map((comment) => comment.body)].join('\0')
 
-  let issueIds = extractResolvedIssueKeysFromText(prBody || '')
-
-  for (const comment of comments) {
-    issueIds = [...issueIds, ...extractResolvedIssueKeysFromText(comment.body)]
-  }
-  return [...new Set(issueIds)]
-}
-
-function extractResolvedIssueKeysFromText(text) {
   const keywords = [
     'close',
     'closes',
@@ -42429,7 +42423,7 @@ function extractResolvedIssueKeysFromText(text) {
   // It’s extremely important for this regexp to match only simple
   // jira keys as extracted keys will be used in JQL queries.
   const issueKeyRegExp = '[A-Z]+-[0-9]+'
-  const urlRegExp = `https://${jiraDomain}/browse/(${issueKeyRegExp})`
+  const urlRegExp = `${jiraApiBaseUrl.origin}/browse/(${issueKeyRegExp})`
   const closesRegExp = `${keywordsRegExp}${urlRegExp}(?:\\s*,\\s*${urlRegExp})*`
 
   // Find all “Closes URL, URL…”
@@ -42440,7 +42434,7 @@ function extractResolvedIssueKeysFromText(text) {
       matches.flatMap((match) => {
         // Find URLs
         const urlMatches = match.match(new RegExp(urlRegExp, 'g'))
-        // Find issueId in the URL (only capture group in urlRegexp)
+        // Find issueId in the URL (only capture group in urlRegExp)
         const issueKeys = urlMatches.map(
           (url) => url.match(new RegExp(urlRegExp))[1]
         )
@@ -42549,7 +42543,7 @@ async function transitionIssues(issueKeys, newStatusName) {
 async function main() {
   try {
     const comments = await getPullRequestComments()
-    const issueIds = await extractResolvedIssueKeys(pr.body, comments)
+    const issueIds = extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
       if (context.eventName === 'pull_request' && payload.action === 'opened') {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42332,6 +42332,7 @@ const {
   context,
   context: { payload, repo },
 } = github_namespaceObject
+const pr = payload.pull_request || payload.issue
 
 const githubToken = core.getInput('github-token')
 const githubRequireKeywordPrefix =
@@ -42377,11 +42378,11 @@ function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
-async function getIssues(issuesIds) {
+async function getIssues(issuesKeys) {
   const response = await jiraApi.get('search', {
     params: {
       maxResults: 100,
-      jql: `id in (${issuesIds.join(',')})`,
+      jql: `id in (${issuesKeys.join(',')})`,
       fields: 'status',
       expand: 'transitions',
     },
@@ -42398,18 +42399,18 @@ async function getIssues(issuesIds) {
   }))
 }
 
-async function getIssueIds(prBody, comments) {
+async function extractResolvedIssueKeys(prBody, comments) {
   console.log('Searching for issue ids')
 
-  let issueIds = matchIssueIds(prBody || '')
+  let issueIds = extractResolvedIssueKeysFromText(prBody || '')
 
   for (const comment of comments) {
-    issueIds = [...issueIds, ...matchIssueIds(comment.body)]
+    issueIds = [...issueIds, ...extractResolvedIssueKeysFromText(comment.body)]
   }
   return [...new Set(issueIds)]
 }
 
-function matchIssueIds(text) {
+function extractResolvedIssueKeysFromText(text) {
   const keywords = [
     'close',
     'closes',
@@ -42427,8 +42428,8 @@ function matchIssueIds(text) {
   // Warning:
   // It’s extremely important for this regexp to match only simple
   // jira keys as extracted keys will be used in JQL queries.
-  const issueIdRegExp = '[A-Z]+-[0-9]+'
-  const urlRegExp = `https://${jiraDomain}/browse/(${issueIdRegExp})`
+  const issueKeyRegExp = '[A-Z]+-[0-9]+'
+  const urlRegExp = `https://${jiraDomain}/browse/(${issueKeyRegExp})`
   const closesRegExp = `${keywordsRegExp}${urlRegExp}(?:\\s*,\\s*${urlRegExp})*`
 
   // Find all “Closes URL, URL…”
@@ -42440,10 +42441,10 @@ function matchIssueIds(text) {
         // Find URLs
         const urlMatches = match.match(new RegExp(urlRegExp, 'g'))
         // Find issueId in the URL (only capture group in urlRegexp)
-        const issueIds = urlMatches.map(
+        const issueKeys = urlMatches.map(
           (url) => url.match(new RegExp(urlRegExp))[1]
         )
-        return issueIds
+        return issueKeys
       })
     )
   )
@@ -42460,10 +42461,19 @@ async function getPullRequestComments() {
   return response.data
 }
 
-async function assignPrToIssues(issueIds, pr) {
+async function nagToLinkJiraIssue() {
+  await octokit.rest.issues.createComment({
+    issue_number: pr.number,
+    owner: repo.owner,
+    repo: repo.repo,
+    body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
+  })
+}
+
+async function assignPrToIssues(issueKeys) {
   await Promise.all(
-    issueIds.map(async (issueId) => {
-      console.log('Assigning PR', `#${pr.number}`, 'to issue', issueId)
+    issueKeys.map(async (issueKey) => {
+      console.log('Assigning PR', `#${pr.number}`, 'to issue', issueKey)
 
       const prLinkObject = {
         url: pr.html_url,
@@ -42473,14 +42483,14 @@ async function assignPrToIssues(issueIds, pr) {
       }
 
       const { data: links } = await jiraApi.get(
-        `issue/${encodeURIComponent(issueId)}/remotelink`
+        `issue/${encodeURIComponent(issueKey)}/remotelink`
       )
 
       const alreadyAssigned = links.some(
         (link) => link.object.url === prLinkObject.url
       )
       if (!alreadyAssigned) {
-        await jiraApi.post(`issue/${encodeURIComponent(issueId)}/remotelink`, {
+        await jiraApi.post(`issue/${encodeURIComponent(issueKey)}/remotelink`, {
           application: {},
           object: prLinkObject,
         })
@@ -42488,13 +42498,19 @@ async function assignPrToIssues(issueIds, pr) {
     })
   )
 
-  console.log('Assigned PR', `#${pr.number}`, 'to', issueIds.length, 'issue(s)')
+  console.log(
+    'Assigned PR',
+    `#${pr.number}`,
+    'to',
+    issueKeys.length,
+    'issue(s)'
+  )
 }
 
-async function transitionIssues(issuesIds, newStatusName) {
+async function transitionIssues(issueKeys, newStatusName) {
   const newStatusNameNormalised = normaliseStatusName(newStatusName)
 
-  const issuesData = await getIssues(issuesIds)
+  const issuesData = await getIssues(issueKeys)
 
   return Promise.all(
     issuesData.map(
@@ -42531,20 +42547,13 @@ async function transitionIssues(issuesIds, newStatusName) {
 }
 
 async function main() {
-  const pr = payload.pull_request || payload.issue
-
   try {
     const comments = await getPullRequestComments()
-    const issueIds = await getIssueIds(pr.body, comments)
+    const issueIds = await extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
       if (context.eventName === 'pull_request' && payload.action === 'opened') {
-        octokit.rest.issues.createComment({
-          issue_number: pr.number,
-          owner: repo.owner,
-          repo: repo.repo,
-          body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
-        })
+        void nagToLinkJiraIssue()
       }
 
       console.log('Could not find issue IDs')
@@ -42561,7 +42570,7 @@ async function main() {
     const isFauxDraft = Boolean(pr.title.match(titleDraftRegExp))
     const isDraft = isRealDraft || isFauxDraft
 
-    await assignPrToIssues(issueIds, pr)
+    await assignPrToIssues(issueIds)
 
     if (pr.state === 'open' && isDraft) {
       if (!jiraListPrDraft) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42369,6 +42369,10 @@ jiraApi.interceptors.response.use(
   }
 )
 
+const octokit = github.getOctokit(githubToken)
+const repoOwner = (payload.organization || payload.repository.owner).login
+const issueNumber = (payload.pull_request || payload.issue).number
+
 function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
@@ -42392,79 +42396,6 @@ async function getIssues(issuesIds) {
         .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
     ),
   }))
-}
-
-const octokit = github.getOctokit(githubToken)
-const repoOwner = (payload.organization || payload.repository.owner).login
-const issueNumber = (payload.pull_request || payload.issue).number
-
-async function main() {
-  const pr = payload.pull_request || payload.issue
-
-  try {
-    const comments = await getPullRequestComments()
-    const issueIds = await getIssueIds(pr.body, comments)
-
-    if (!issueIds.length) {
-      if (context.eventName === 'pull_request' && payload.action === 'opened') {
-        octokit.rest.issues.createComment({
-          issue_number: pr.number,
-          owner: repo.owner,
-          repo: repo.repo,
-          body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
-        })
-      }
-
-      console.log('Could not find issue IDs')
-      return
-    }
-    console.log('Found issue IDs:', issueIds.join(', '))
-
-    // Treat PRs with “draft” or “wip” in brackets at the start or
-    // end of the titles like drafts. Useful for orgs on unpaid
-    // plans which doesn’t support PR drafts.
-    const titleDraftRegExp =
-      /^(?:\s*[\[(](?:wip|draft)[\])]\s+)|(?:\s+[\[(](?:wip|draft)[\])]\s*)$/i
-    const isRealDraft = pr.draft === true
-    const isFauxDraft = Boolean(pr.title.match(titleDraftRegExp))
-    const isDraft = isRealDraft || isFauxDraft
-
-    await assignPrToIssues(issueIds, pr)
-
-    if (pr.state === 'open' && isDraft) {
-      if (!jiraListPrDraft) {
-        console.log(
-          'No draft PR status name provided, skipping transitioning issues'
-        )
-      } else {
-        await transitionIssues(issueIds, jiraListPrDraft)
-      }
-    } else if (pr.state === 'open' && !isDraft) {
-      if (!jiraListPrReady) {
-        console.log(
-          'No ready PR status name provided, skipping transitioning issues'
-        )
-      } else {
-        await transitionIssues(issueIds, jiraListPrReady)
-      }
-    } else if (pr.state === 'closed') {
-      if (!jiraListPrMerged) {
-        console.log(
-          'No merged PR status name provided, skipping transitioning issues'
-        )
-      } else {
-        await transitionIssues(issueIds, jiraListPrMerged)
-      }
-    } else {
-      console.log(
-        'Skipping transitioning the issues:',
-        `pr.state=${pr.state},`,
-        pr.draft ? 'draft' : isFauxDraft ? 'faux draft' : 'not draft'
-      )
-    }
-  } catch (error) {
-    core.setFailed(error)
-  }
 }
 
 async function getIssueIds(prBody, comments) {
@@ -42597,6 +42528,75 @@ async function transitionIssues(issuesIds, newStatusName) {
       }
     )
   )
+}
+
+async function main() {
+  const pr = payload.pull_request || payload.issue
+
+  try {
+    const comments = await getPullRequestComments()
+    const issueIds = await getIssueIds(pr.body, comments)
+
+    if (!issueIds.length) {
+      if (context.eventName === 'pull_request' && payload.action === 'opened') {
+        octokit.rest.issues.createComment({
+          issue_number: pr.number,
+          owner: repo.owner,
+          repo: repo.repo,
+          body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
+        })
+      }
+
+      console.log('Could not find issue IDs')
+      return
+    }
+    console.log('Found issue IDs:', issueIds.join(', '))
+
+    // Treat PRs with “draft” or “wip” in brackets at the start or
+    // end of the titles like drafts. Useful for orgs on unpaid
+    // plans which doesn’t support PR drafts.
+    const titleDraftRegExp =
+      /^(?:\s*[\[(](?:wip|draft)[\])]\s+)|(?:\s+[\[(](?:wip|draft)[\])]\s*)$/i
+    const isRealDraft = pr.draft === true
+    const isFauxDraft = Boolean(pr.title.match(titleDraftRegExp))
+    const isDraft = isRealDraft || isFauxDraft
+
+    await assignPrToIssues(issueIds, pr)
+
+    if (pr.state === 'open' && isDraft) {
+      if (!jiraListPrDraft) {
+        console.log(
+          'No draft PR status name provided, skipping transitioning issues'
+        )
+      } else {
+        await transitionIssues(issueIds, jiraListPrDraft)
+      }
+    } else if (pr.state === 'open' && !isDraft) {
+      if (!jiraListPrReady) {
+        console.log(
+          'No ready PR status name provided, skipping transitioning issues'
+        )
+      } else {
+        await transitionIssues(issueIds, jiraListPrReady)
+      }
+    } else if (pr.state === 'closed') {
+      if (!jiraListPrMerged) {
+        console.log(
+          'No merged PR status name provided, skipping transitioning issues'
+        )
+      } else {
+        await transitionIssues(issueIds, jiraListPrMerged)
+      }
+    } else {
+      console.log(
+        'Skipping transitioning the issues:',
+        `pr.state=${pr.state},`,
+        pr.draft ? 'draft' : isFauxDraft ? 'faux draft' : 'not draft'
+      )
+    }
+  } catch (error) {
+    core.setFailed(error)
+  }
 }
 
 main()

--- a/index.mjs
+++ b/index.mjs
@@ -23,9 +23,9 @@ const githubRequireKeywordPrefix =
 const jiraDomain = core.getInput('jira-domain', { required: true })
 const jiraUser = core.getInput('jira-user', { required: true })
 const jiraApiToken = core.getInput('jira-api-token', { required: true })
-const jiraListPrDraft = core.getInput('jira-list-pr-draft')
-const jiraListPrReady = core.getInput('jira-list-pr-ready')
-const jiraListPrMerged = core.getInput('jira-list-pr-merged')
+const jiraStatusPrDraft = core.getInput('jira-status-pr-draft')
+const jiraStatusPrReady = core.getInput('jira-status-pr-ready')
+const jiraStatusPrMerged = core.getInput('jira-status-pr-merged')
 
 const jiraApi = axios.create({
   // https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/
@@ -255,28 +255,28 @@ async function main() {
     await assignPrToIssues(issueIds)
 
     if (pr.state === 'open' && isDraft) {
-      if (!jiraListPrDraft) {
+      if (!jiraStatusPrDraft) {
         console.log(
           'No draft PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraListPrDraft)
+        await transitionIssues(issueIds, jiraStatusPrDraft)
       }
     } else if (pr.state === 'open' && !isDraft) {
-      if (!jiraListPrReady) {
+      if (!jiraStatusPrReady) {
         console.log(
           'No ready PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraListPrReady)
+        await transitionIssues(issueIds, jiraStatusPrReady)
       }
     } else if (pr.state === 'closed') {
-      if (!jiraListPrMerged) {
+      if (!jiraStatusPrMerged) {
         console.log(
           'No merged PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraListPrMerged)
+        await transitionIssues(issueIds, jiraStatusPrMerged)
       }
     } else {
       console.log(

--- a/index.mjs
+++ b/index.mjs
@@ -20,16 +20,19 @@ const githubToken = core.getInput('github-token')
 const githubRequireKeywordPrefix =
   core.getInput('github-require-keyword-prefix') ?? true
 
-const jiraDomain = core.getInput('jira-domain', { required: true })
+const jiraDomainInput = core.getInput('jira-domain', { required: true })
 const jiraUser = core.getInput('jira-user', { required: true })
 const jiraApiToken = core.getInput('jira-api-token', { required: true })
 const jiraStatusPrDraft = core.getInput('jira-status-pr-draft')
 const jiraStatusPrReady = core.getInput('jira-status-pr-ready')
 const jiraStatusPrMerged = core.getInput('jira-status-pr-merged')
 
+// https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/
+const jiraApiBaseUrl = new URL(`https://${jiraDomainInput}`)
+jiraApiBaseUrl.pathname = '/rest/api/2'
+
 const jiraApi = axios.create({
-  // https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/
-  baseURL: `https://${jiraDomain}/rest/api/2`,
+  baseURL: jiraApiBaseUrl.toString(),
   headers: {
     'Accept': 'application/json',
     'Content-Type': 'application/json',
@@ -81,18 +84,9 @@ async function getIssues(issuesKeys) {
   }))
 }
 
-async function extractResolvedIssueKeys(prBody, comments) {
-  console.log('Searching for issue ids')
+function extractResolvedIssueKeys(prBody, comments) {
+  const text = [prBody, ...comments.map((comment) => comment.body)].join('\0')
 
-  let issueIds = extractResolvedIssueKeysFromText(prBody || '')
-
-  for (const comment of comments) {
-    issueIds = [...issueIds, ...extractResolvedIssueKeysFromText(comment.body)]
-  }
-  return [...new Set(issueIds)]
-}
-
-function extractResolvedIssueKeysFromText(text) {
   const keywords = [
     'close',
     'closes',
@@ -111,7 +105,7 @@ function extractResolvedIssueKeysFromText(text) {
   // It’s extremely important for this regexp to match only simple
   // jira keys as extracted keys will be used in JQL queries.
   const issueKeyRegExp = '[A-Z]+-[0-9]+'
-  const urlRegExp = `https://${jiraDomain}/browse/(${issueKeyRegExp})`
+  const urlRegExp = `${jiraApiBaseUrl.origin}/browse/(${issueKeyRegExp})`
   const closesRegExp = `${keywordsRegExp}${urlRegExp}(?:\\s*,\\s*${urlRegExp})*`
 
   // Find all “Closes URL, URL…”
@@ -122,7 +116,7 @@ function extractResolvedIssueKeysFromText(text) {
       matches.flatMap((match) => {
         // Find URLs
         const urlMatches = match.match(new RegExp(urlRegExp, 'g'))
-        // Find issueId in the URL (only capture group in urlRegexp)
+        // Find issueId in the URL (only capture group in urlRegExp)
         const issueKeys = urlMatches.map(
           (url) => url.match(new RegExp(urlRegExp))[1]
         )
@@ -231,7 +225,7 @@ async function transitionIssues(issueKeys, newStatusName) {
 async function main() {
   try {
     const comments = await getPullRequestComments()
-    const issueIds = await extractResolvedIssueKeys(pr.body, comments)
+    const issueIds = extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
       if (context.eventName === 'pull_request' && payload.action === 'opened') {

--- a/index.mjs
+++ b/index.mjs
@@ -14,6 +14,7 @@ const {
   context,
   context: { payload, repo },
 } = github
+const pr = payload.pull_request || payload.issue
 
 const githubToken = core.getInput('github-token')
 const githubRequireKeywordPrefix =
@@ -59,11 +60,11 @@ function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
-async function getIssues(issuesIds) {
+async function getIssues(issuesKeys) {
   const response = await jiraApi.get('search', {
     params: {
       maxResults: 100,
-      jql: `id in (${issuesIds.join(',')})`,
+      jql: `id in (${issuesKeys.join(',')})`,
       fields: 'status',
       expand: 'transitions',
     },
@@ -80,18 +81,18 @@ async function getIssues(issuesIds) {
   }))
 }
 
-async function getIssueIds(prBody, comments) {
+async function extractResolvedIssueKeys(prBody, comments) {
   console.log('Searching for issue ids')
 
-  let issueIds = matchIssueIds(prBody || '')
+  let issueIds = extractResolvedIssueKeysFromText(prBody || '')
 
   for (const comment of comments) {
-    issueIds = [...issueIds, ...matchIssueIds(comment.body)]
+    issueIds = [...issueIds, ...extractResolvedIssueKeysFromText(comment.body)]
   }
   return [...new Set(issueIds)]
 }
 
-function matchIssueIds(text) {
+function extractResolvedIssueKeysFromText(text) {
   const keywords = [
     'close',
     'closes',
@@ -109,8 +110,8 @@ function matchIssueIds(text) {
   // Warning:
   // It’s extremely important for this regexp to match only simple
   // jira keys as extracted keys will be used in JQL queries.
-  const issueIdRegExp = '[A-Z]+-[0-9]+'
-  const urlRegExp = `https://${jiraDomain}/browse/(${issueIdRegExp})`
+  const issueKeyRegExp = '[A-Z]+-[0-9]+'
+  const urlRegExp = `https://${jiraDomain}/browse/(${issueKeyRegExp})`
   const closesRegExp = `${keywordsRegExp}${urlRegExp}(?:\\s*,\\s*${urlRegExp})*`
 
   // Find all “Closes URL, URL…”
@@ -122,10 +123,10 @@ function matchIssueIds(text) {
         // Find URLs
         const urlMatches = match.match(new RegExp(urlRegExp, 'g'))
         // Find issueId in the URL (only capture group in urlRegexp)
-        const issueIds = urlMatches.map(
+        const issueKeys = urlMatches.map(
           (url) => url.match(new RegExp(urlRegExp))[1]
         )
-        return issueIds
+        return issueKeys
       })
     )
   )
@@ -142,10 +143,19 @@ async function getPullRequestComments() {
   return response.data
 }
 
-async function assignPrToIssues(issueIds, pr) {
+async function nagToLinkJiraIssue() {
+  await octokit.rest.issues.createComment({
+    issue_number: pr.number,
+    owner: repo.owner,
+    repo: repo.repo,
+    body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
+  })
+}
+
+async function assignPrToIssues(issueKeys) {
   await Promise.all(
-    issueIds.map(async (issueId) => {
-      console.log('Assigning PR', `#${pr.number}`, 'to issue', issueId)
+    issueKeys.map(async (issueKey) => {
+      console.log('Assigning PR', `#${pr.number}`, 'to issue', issueKey)
 
       const prLinkObject = {
         url: pr.html_url,
@@ -155,14 +165,14 @@ async function assignPrToIssues(issueIds, pr) {
       }
 
       const { data: links } = await jiraApi.get(
-        `issue/${encodeURIComponent(issueId)}/remotelink`
+        `issue/${encodeURIComponent(issueKey)}/remotelink`
       )
 
       const alreadyAssigned = links.some(
         (link) => link.object.url === prLinkObject.url
       )
       if (!alreadyAssigned) {
-        await jiraApi.post(`issue/${encodeURIComponent(issueId)}/remotelink`, {
+        await jiraApi.post(`issue/${encodeURIComponent(issueKey)}/remotelink`, {
           application: {},
           object: prLinkObject,
         })
@@ -170,13 +180,19 @@ async function assignPrToIssues(issueIds, pr) {
     })
   )
 
-  console.log('Assigned PR', `#${pr.number}`, 'to', issueIds.length, 'issue(s)')
+  console.log(
+    'Assigned PR',
+    `#${pr.number}`,
+    'to',
+    issueKeys.length,
+    'issue(s)'
+  )
 }
 
-async function transitionIssues(issuesIds, newStatusName) {
+async function transitionIssues(issueKeys, newStatusName) {
   const newStatusNameNormalised = normaliseStatusName(newStatusName)
 
-  const issuesData = await getIssues(issuesIds)
+  const issuesData = await getIssues(issueKeys)
 
   return Promise.all(
     issuesData.map(
@@ -213,20 +229,13 @@ async function transitionIssues(issuesIds, newStatusName) {
 }
 
 async function main() {
-  const pr = payload.pull_request || payload.issue
-
   try {
     const comments = await getPullRequestComments()
-    const issueIds = await getIssueIds(pr.body, comments)
+    const issueIds = await extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
       if (context.eventName === 'pull_request' && payload.action === 'opened') {
-        octokit.rest.issues.createComment({
-          issue_number: pr.number,
-          owner: repo.owner,
-          repo: repo.repo,
-          body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
-        })
+        void nagToLinkJiraIssue()
       }
 
       console.log('Could not find issue IDs')
@@ -243,7 +252,7 @@ async function main() {
     const isFauxDraft = Boolean(pr.title.match(titleDraftRegExp))
     const isDraft = isRealDraft || isFauxDraft
 
-    await assignPrToIssues(issueIds, pr)
+    await assignPrToIssues(issueIds)
 
     if (pr.state === 'open' && isDraft) {
       if (!jiraListPrDraft) {

--- a/index.mjs
+++ b/index.mjs
@@ -5,8 +5,10 @@ import * as github from '@actions/github'
 // Use these for local debugging.
 // You will also need `mock-inputs.json` with input values.
 //
-// import * as core from './mock.mjs'
-// import * as github from './mock.mjs'
+// import * as mock from './mock.mjs'
+//
+// const core = mock
+// const github = mock
 
 const {
   context,
@@ -53,22 +55,28 @@ function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
-async function getIssueStatusName(issueId) {
-  const response = await jiraApi.get(`issue/${encodeURIComponent(issueId)}`)
-  const currentStatusName = response.data.fields.status.name
-  return normaliseStatusName(currentStatusName)
-}
+async function getIssue(issueId) {
+  const response = await jiraApi.get(`issue/${encodeURIComponent(issueId)}`, {
+    params: {
+      fields: 'status',
+      expand: 'transitions',
+    },
+  })
+  const {
+    data: {
+      fields: { status },
+      transitions,
+    },
+  } = response
 
-async function getIssueTransitionIds(issueId) {
-  const response = await jiraApi.get(
-    `issue/${encodeURIComponent(issueId)}/transitions`
-  )
-  const { transitions } = response.data
-  return new Map(
-    transitions
-      .filter((t) => t.isAvailable)
-      .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
-  )
+  return {
+    currentStatusName: normaliseStatusName(status.name),
+    availableTransitions: new Map(
+      transitions
+        .filter((t) => t.isAvailable)
+        .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
+    ),
+  }
 }
 
 const octokit = github.getOctokit(githubToken)
@@ -114,13 +122,7 @@ async function main() {
           'No draft PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssue(issueIds, jiraListPrDraft)
-        console.log(
-          'Transitioned',
-          issueIds.length,
-          'issue(s) to',
-          jiraListPrDraft
-        )
+        await transitionIssues(issueIds, jiraListPrDraft)
       }
     } else if (pr.state === 'open' && !isDraft) {
       if (!jiraListPrReady) {
@@ -128,13 +130,7 @@ async function main() {
           'No ready PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssue(issueIds, jiraListPrReady)
-        console.log(
-          'Transitioned',
-          issueIds.length,
-          'issue(s) to',
-          jiraListPrReady
-        )
+        await transitionIssues(issueIds, jiraListPrReady)
       }
     } else if (pr.state === 'closed') {
       if (!jiraListPrMerged) {
@@ -142,13 +138,7 @@ async function main() {
           'No merged PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssue(issueIds, jiraListPrMerged)
-        console.log(
-          'Transitioned',
-          issueIds.length,
-          'issue(s) to',
-          jiraListPrMerged
-        )
+        await transitionIssues(issueIds, jiraListPrMerged)
       }
     } else {
       console.log(
@@ -251,22 +241,26 @@ async function assignPrToIssues(issueIds, pr) {
   console.log('Assigned PR', `#${pr.number}`, 'to', issueIds.length, 'issue(s)')
 }
 
-async function transitionIssue(issueIds, newStatusName) {
+async function transitionIssues(issueIds, newStatusName) {
   return Promise.all(
     issueIds.map(async (issueId) => {
-      console.log('Transitioning issue', issueId, 'to', newStatusName)
-
       const newStatusNameNormalised = normaliseStatusName(newStatusName)
 
-      const currentStatusName = await getIssueStatusName(issueId)
+      const { currentStatusName, availableTransitions } =
+        await getIssue(issueId)
 
-      if (currentStatusName !== newStatusNameNormalised) {
-        const transitionIds = await getIssueTransitionIds(issueId)
-
-        const newStatusId = transitionIds.get(newStatusNameNormalised)
+      if (currentStatusName === newStatusNameNormalised) {
+        console.log(
+          'Did not transition',
+          issueId,
+          '— already in',
+          newStatusName
+        )
+      } else {
+        const newStatusId = availableTransitions.get(newStatusNameNormalised)
         if (newStatusId == null) {
           throw new Error(
-            `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(transitionIds.keys()).join(', ')}`
+            `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(availableTransitions.keys()).join(', ')}`
           )
         }
 
@@ -275,6 +269,8 @@ async function transitionIssue(issueIds, newStatusName) {
             id: newStatusId,
           },
         })
+
+        console.log('Transitioned', issueId, 'to', newStatusName)
       }
     })
   )

--- a/index.mjs
+++ b/index.mjs
@@ -51,6 +51,10 @@ jiraApi.interceptors.response.use(
   }
 )
 
+const octokit = github.getOctokit(githubToken)
+const repoOwner = (payload.organization || payload.repository.owner).login
+const issueNumber = (payload.pull_request || payload.issue).number
+
 function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
@@ -74,79 +78,6 @@ async function getIssues(issuesIds) {
         .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
     ),
   }))
-}
-
-const octokit = github.getOctokit(githubToken)
-const repoOwner = (payload.organization || payload.repository.owner).login
-const issueNumber = (payload.pull_request || payload.issue).number
-
-async function main() {
-  const pr = payload.pull_request || payload.issue
-
-  try {
-    const comments = await getPullRequestComments()
-    const issueIds = await getIssueIds(pr.body, comments)
-
-    if (!issueIds.length) {
-      if (context.eventName === 'pull_request' && payload.action === 'opened') {
-        octokit.rest.issues.createComment({
-          issue_number: pr.number,
-          owner: repo.owner,
-          repo: repo.repo,
-          body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
-        })
-      }
-
-      console.log('Could not find issue IDs')
-      return
-    }
-    console.log('Found issue IDs:', issueIds.join(', '))
-
-    // Treat PRs with “draft” or “wip” in brackets at the start or
-    // end of the titles like drafts. Useful for orgs on unpaid
-    // plans which doesn’t support PR drafts.
-    const titleDraftRegExp =
-      /^(?:\s*[\[(](?:wip|draft)[\])]\s+)|(?:\s+[\[(](?:wip|draft)[\])]\s*)$/i
-    const isRealDraft = pr.draft === true
-    const isFauxDraft = Boolean(pr.title.match(titleDraftRegExp))
-    const isDraft = isRealDraft || isFauxDraft
-
-    await assignPrToIssues(issueIds, pr)
-
-    if (pr.state === 'open' && isDraft) {
-      if (!jiraListPrDraft) {
-        console.log(
-          'No draft PR status name provided, skipping transitioning issues'
-        )
-      } else {
-        await transitionIssues(issueIds, jiraListPrDraft)
-      }
-    } else if (pr.state === 'open' && !isDraft) {
-      if (!jiraListPrReady) {
-        console.log(
-          'No ready PR status name provided, skipping transitioning issues'
-        )
-      } else {
-        await transitionIssues(issueIds, jiraListPrReady)
-      }
-    } else if (pr.state === 'closed') {
-      if (!jiraListPrMerged) {
-        console.log(
-          'No merged PR status name provided, skipping transitioning issues'
-        )
-      } else {
-        await transitionIssues(issueIds, jiraListPrMerged)
-      }
-    } else {
-      console.log(
-        'Skipping transitioning the issues:',
-        `pr.state=${pr.state},`,
-        pr.draft ? 'draft' : isFauxDraft ? 'faux draft' : 'not draft'
-      )
-    }
-  } catch (error) {
-    core.setFailed(error)
-  }
 }
 
 async function getIssueIds(prBody, comments) {
@@ -279,6 +210,75 @@ async function transitionIssues(issuesIds, newStatusName) {
       }
     )
   )
+}
+
+async function main() {
+  const pr = payload.pull_request || payload.issue
+
+  try {
+    const comments = await getPullRequestComments()
+    const issueIds = await getIssueIds(pr.body, comments)
+
+    if (!issueIds.length) {
+      if (context.eventName === 'pull_request' && payload.action === 'opened') {
+        octokit.rest.issues.createComment({
+          issue_number: pr.number,
+          owner: repo.owner,
+          repo: repo.repo,
+          body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
+        })
+      }
+
+      console.log('Could not find issue IDs')
+      return
+    }
+    console.log('Found issue IDs:', issueIds.join(', '))
+
+    // Treat PRs with “draft” or “wip” in brackets at the start or
+    // end of the titles like drafts. Useful for orgs on unpaid
+    // plans which doesn’t support PR drafts.
+    const titleDraftRegExp =
+      /^(?:\s*[\[(](?:wip|draft)[\])]\s+)|(?:\s+[\[(](?:wip|draft)[\])]\s*)$/i
+    const isRealDraft = pr.draft === true
+    const isFauxDraft = Boolean(pr.title.match(titleDraftRegExp))
+    const isDraft = isRealDraft || isFauxDraft
+
+    await assignPrToIssues(issueIds, pr)
+
+    if (pr.state === 'open' && isDraft) {
+      if (!jiraListPrDraft) {
+        console.log(
+          'No draft PR status name provided, skipping transitioning issues'
+        )
+      } else {
+        await transitionIssues(issueIds, jiraListPrDraft)
+      }
+    } else if (pr.state === 'open' && !isDraft) {
+      if (!jiraListPrReady) {
+        console.log(
+          'No ready PR status name provided, skipping transitioning issues'
+        )
+      } else {
+        await transitionIssues(issueIds, jiraListPrReady)
+      }
+    } else if (pr.state === 'closed') {
+      if (!jiraListPrMerged) {
+        console.log(
+          'No merged PR status name provided, skipping transitioning issues'
+        )
+      } else {
+        await transitionIssues(issueIds, jiraListPrMerged)
+      }
+    } else {
+      console.log(
+        'Skipping transitioning the issues:',
+        `pr.state=${pr.state},`,
+        pr.draft ? 'draft' : isFauxDraft ? 'faux draft' : 'not draft'
+      )
+    }
+  } catch (error) {
+    core.setFailed(error)
+  }
 }
 
 main()

--- a/index.mjs
+++ b/index.mjs
@@ -49,6 +49,16 @@ jiraApi.interceptors.response.use(
   }
 )
 
+function normaliseStatusName(name) {
+  return name.trim().toLowerCase().replace(/\s+/g, ' ')
+}
+
+async function getIssueStatusName(issueId) {
+  const response = await jiraApi.get(`issue/${encodeURIComponent(issueId)}`)
+  const currentStatusName = response.data.fields.status.name
+  return normaliseStatusName(currentStatusName)
+}
+
 async function getIssueTransitionIds(issueId) {
   const response = await jiraApi.get(
     `issue/${encodeURIComponent(issueId)}/transitions`
@@ -57,7 +67,7 @@ async function getIssueTransitionIds(issueId) {
   return new Map(
     transitions
       .filter((t) => t.isAvailable)
-      .map((t) => [t.name.toLowerCase(), Number.parseInt(t.id, 10)])
+      .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
   )
 }
 
@@ -101,7 +111,7 @@ async function main() {
     if (pr.state === 'open' && isDraft) {
       if (!jiraListPrDraft) {
         console.log(
-          'No draft PR list name provided, skipping transitioning issues'
+          'No draft PR status name provided, skipping transitioning issues'
         )
       } else {
         await transitionIssue(issueIds, jiraListPrDraft)
@@ -115,7 +125,7 @@ async function main() {
     } else if (pr.state === 'open' && !isDraft) {
       if (!jiraListPrReady) {
         console.log(
-          'No ready PR list name provided, skipping transitioning issues'
+          'No ready PR status name provided, skipping transitioning issues'
         )
       } else {
         await transitionIssue(issueIds, jiraListPrReady)
@@ -129,7 +139,7 @@ async function main() {
     } else if (pr.state === 'closed') {
       if (!jiraListPrMerged) {
         console.log(
-          'No merged PR list name provided, skipping transitioning issues'
+          'No merged PR status name provided, skipping transitioning issues'
         )
       } else {
         await transitionIssue(issueIds, jiraListPrMerged)
@@ -241,25 +251,31 @@ async function assignPrToIssues(issueIds, pr) {
   console.log('Assigned PR', `#${pr.number}`, 'to', issueIds.length, 'issue(s)')
 }
 
-async function transitionIssue(issueIds, listName) {
+async function transitionIssue(issueIds, newStatusName) {
   return Promise.all(
     issueIds.map(async (issueId) => {
-      console.log('Transitioned issue', issueId, 'to', listName)
+      console.log('Transitioning issue', issueId, 'to', newStatusName)
 
-      const transitionIds = await getIssueTransitionIds(issueId)
+      const newStatusNameNormalised = normaliseStatusName(newStatusName)
 
-      const listId = transitionIds.get(listName.toLowerCase())
-      if (listId == null) {
-        throw new Error(
-          `List name ${listName} not found in JIRA. Available lists: ${Array.from(transitionIds.keys()).join(', ')}`
-        )
+      const currentStatusName = await getIssueStatusName(issueId)
+
+      if (currentStatusName !== newStatusNameNormalised) {
+        const transitionIds = await getIssueTransitionIds(issueId)
+
+        const newStatusId = transitionIds.get(newStatusNameNormalised)
+        if (newStatusId == null) {
+          throw new Error(
+            `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(transitionIds.keys()).join(', ')}`
+          )
+        }
+
+        await jiraApi.post(`issue/${encodeURIComponent(issueId)}/transitions`, {
+          transition: {
+            id: newStatusId,
+          },
+        })
       }
-
-      return jiraApi.post(`issue/${encodeURIComponent(issueId)}/transitions`, {
-        transition: {
-          id: listId,
-        },
-      })
     })
   )
 }

--- a/index.mjs
+++ b/index.mjs
@@ -55,28 +55,25 @@ function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
-async function getIssue(issueId) {
-  const response = await jiraApi.get(`issue/${encodeURIComponent(issueId)}`, {
+async function getIssues(issuesIds) {
+  const response = await jiraApi.get('search', {
     params: {
+      maxResults: 100,
+      jql: `id in (${issuesIds.join(',')})`,
       fields: 'status',
       expand: 'transitions',
     },
   })
-  const {
-    data: {
-      fields: { status },
-      transitions,
-    },
-  } = response
 
-  return {
-    currentStatusName: normaliseStatusName(status.name),
+  return response.data.issues.map((jiraIssueData) => ({
+    issueKey: jiraIssueData.key,
+    currentStatusName: normaliseStatusName(jiraIssueData.fields.status.name),
     availableTransitions: new Map(
-      transitions
+      jiraIssueData.transitions
         .filter((t) => t.isAvailable)
         .map((t) => [normaliseStatusName(t.name), Number.parseInt(t.id, 10)])
     ),
-  }
+  }))
 }
 
 const octokit = github.getOctokit(githubToken)
@@ -178,7 +175,11 @@ function matchIssueIds(text) {
   const keywordsRegExp = githubRequireKeywordPrefix
     ? `(?:${keywords.join('|')})\\s+`
     : ''
-  const urlRegExp = `https://${jiraDomain}/browse/([A-Z]+-\\d+)`
+  // Warning:
+  // It’s extremely important for this regexp to match only simple
+  // jira keys as extracted keys will be used in JQL queries.
+  const issueIdRegExp = '[A-Z]+-[0-9]+'
+  const urlRegExp = `https://${jiraDomain}/browse/(${issueIdRegExp})`
   const closesRegExp = `${keywordsRegExp}${urlRegExp}(?:\\s*,\\s*${urlRegExp})*`
 
   // Find all “Closes URL, URL…”
@@ -241,38 +242,42 @@ async function assignPrToIssues(issueIds, pr) {
   console.log('Assigned PR', `#${pr.number}`, 'to', issueIds.length, 'issue(s)')
 }
 
-async function transitionIssues(issueIds, newStatusName) {
+async function transitionIssues(issuesIds, newStatusName) {
+  const newStatusNameNormalised = normaliseStatusName(newStatusName)
+
+  const issuesData = await getIssues(issuesIds)
+
   return Promise.all(
-    issueIds.map(async (issueId) => {
-      const newStatusNameNormalised = normaliseStatusName(newStatusName)
-
-      const { currentStatusName, availableTransitions } =
-        await getIssue(issueId)
-
-      if (currentStatusName === newStatusNameNormalised) {
-        console.log(
-          'Did not transition',
-          issueId,
-          '— already in',
-          newStatusName
-        )
-      } else {
-        const newStatusId = availableTransitions.get(newStatusNameNormalised)
-        if (newStatusId == null) {
-          throw new Error(
-            `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(availableTransitions.keys()).join(', ')}`
+    issuesData.map(
+      async ({ issueKey, currentStatusName, availableTransitions }) => {
+        if (currentStatusName === newStatusNameNormalised) {
+          console.log(
+            'Did not transition',
+            issueKey,
+            '— already in',
+            newStatusName
           )
+        } else {
+          const newStatusId = availableTransitions.get(newStatusNameNormalised)
+          if (newStatusId == null) {
+            throw new Error(
+              `List name ${newStatusName} not found in JIRA. Available statuses: ${Array.from(availableTransitions.keys()).join(', ')}`
+            )
+          }
+
+          await jiraApi.post(
+            `issue/${encodeURIComponent(issueKey)}/transitions`,
+            {
+              transition: {
+                id: newStatusId,
+              },
+            }
+          )
+
+          console.log('Transitioned', issueKey, 'to', newStatusName)
         }
-
-        await jiraApi.post(`issue/${encodeURIComponent(issueId)}/transitions`, {
-          transition: {
-            id: newStatusId,
-          },
-        })
-
-        console.log('Transitioned', issueId, 'to', newStatusName)
       }
-    })
+    )
   )
 }
 


### PR DESCRIPTION
# Why?

🚀

Closes https://verkstedt.atlassian.net/browse/VIP-29

# What?

- **Don’t transition issues when there’s no need**
- **Fetch all issues’ data in a single request**

# What else?

- Rename issue “id” to “key” and “list” to “status”
- **Instruct where to get Jira API token from**
- **Reorder functions**
- **Simplify “Closes URL” extraction**

Sorry for the reorganising 🙇 — it will make it harder to review, but hopefully easier to maintain in the future.

## Checklist

- [x] Ran `prettier -w .`
- [x] Ran `npm run build`
