### PR TITLE
No Jira URL in PR body nag for non–feature branches

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42603,7 +42603,12 @@ async function main() {
     const issueIds = extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
-      if (context.eventName === 'pull_request' && payload.action === 'opened') {
+      if (
+        context.eventName === 'pull_request' &&
+        payload.action === 'opened' &&
+        pr.base.ref !== 'production' &&
+        pr.head.ref !== 'main'
+      ) {
         void nagToLinkJiraIssue()
       }
 

--- a/index.mjs
+++ b/index.mjs
@@ -285,7 +285,11 @@ async function main() {
     const issueIds = extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
-      if (context.eventName === 'pull_request' && payload.action === 'opened') {
+      if (
+        context.eventName === 'pull_request' &&
+        payload.action === 'opened' &&
+        !['main', 'production'].includes(pr.head.ref)
+      ) {
         void nagToLinkJiraIssue()
       }
 


### PR DESCRIPTION
# Why?

Merging `main` to `production` or `production` to `main` doesn’t require a Jira issue link in the PR body.

## Checklist

- [x] Ran `prettier -w .`
- [x] Ran `npm run build`
