### PR TITLE
Use v3 of Jira API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-- Write your changes to `index.js` and not `dist/index.js`
-- Make sure your changes are [prettified](https://prettier.io/)
-- Run `yarn build` before commiting your changes
+- Write your changes to `index.mjs` and not `dist/index.mjs`
+- Make sure EsLint is happy with your changes (`npx eslint index.mjs`)
+- Run `npm run build` before committing your changes

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42382,7 +42382,7 @@ function normaliseStatusName(name) {
 }
 
 async function getIssues(issuesKeys) {
-  const response = await jiraApi.get('api/2/search', {
+  const response = await jiraApi.get('api/3/search', {
     params: {
       maxResults: 100,
       jql: `id in (${issuesKeys.join(',')})`,
@@ -42510,7 +42510,7 @@ function escapeJqlString(str) {
 
 async function getLastIssueInStatusKey(statusName) {
   const statusNameNormalised = normaliseStatusName(statusName)
-  const response = await jiraApi.get('api/2/search', {
+  const response = await jiraApi.get('api/3/search', {
     params: {
       maxResults: 1,
       jql: `status="${escapeJqlString(statusNameNormalised)}" ORDER BY Rank DESC`,
@@ -42606,8 +42606,7 @@ async function main() {
       if (
         context.eventName === 'pull_request' &&
         payload.action === 'opened' &&
-        pr.base.ref !== 'production' &&
-        pr.head.ref !== 'main'
+        !['main', 'production'].includes(pr.head.ref)
       ) {
         void nagToLinkJiraIssue()
       }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42345,15 +42345,17 @@ const jiraStatusPrDraft = core.getInput('jira-status-pr-draft')
 const jiraStatusPrReady = core.getInput('jira-status-pr-ready')
 const jiraStatusPrMerged = core.getInput('jira-status-pr-merged')
 
+const headers = {
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+}
+
 const auth = {
   username: jiraUser,
   password: jiraApiToken,
 }
 
-const headers = {
-  'Accept': 'application/json',
-  'Content-Type': 'application/json',
-}
+const timeoutMs = 10_000
 
 /** @param {import('axios').AxiosError} error */
 function onRejected(error) {
@@ -42370,10 +42372,11 @@ const jiraApi = lib_axios.create({
   baseURL: jiraApiBaseUrl.toString(),
   headers,
   auth,
+  timeout: timeoutMs,
 })
 jiraApi.interceptors.response.use(null, onRejected)
 
-// https://docs.atlassian.com/jira-software/REST/7.0.4/
+// https://developer.atlassian.com/cloud/jira/software/rest/
 const jiraAgileApiBaseUrl = new URL(
   '/rest/agile/1.0/',
   `https://${jiraDomainInput}`
@@ -42382,6 +42385,7 @@ const jiraAgileApi = lib_axios.create({
   baseURL: jiraAgileApiBaseUrl.toString(),
   headers,
   auth,
+  timeout: timeoutMs,
 })
 jiraAgileApi.interceptors.response.use(null, onRejected)
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42553,9 +42553,9 @@ async function transitionIssues(issueKeys, newStatusName) {
         const lastIssueInStatusKey =
           await getLastIssueInStatusKey(newStatusName)
 
-        const transitionedIssueKeys = await Promise.all(
-          sameStatusIssues
-            .map(async ({ issueKey, availableTransitions }) => {
+        const transitionedIssueKeys = (
+          await Promise.all(
+            sameStatusIssues.map(async ({ issueKey, availableTransitions }) => {
               if (currentStatusName === newStatusNameNormalised) {
                 console.log(
                   'Did not transition',
@@ -42587,8 +42587,8 @@ async function transitionIssues(issueKeys, newStatusName) {
                 return issueKey
               }
             })
-            .filter(Boolean)
-        )
+          )
+        ).filter(Boolean)
 
         // Move all newly transitioned issues to the end of the list
         if (transitionedIssueKeys.length > 0 && lastIssueInStatusKey) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42345,33 +42345,45 @@ const jiraStatusPrDraft = core.getInput('jira-status-pr-draft')
 const jiraStatusPrReady = core.getInput('jira-status-pr-ready')
 const jiraStatusPrMerged = core.getInput('jira-status-pr-merged')
 
-// https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/
-const jiraApiBaseUrl = new URL(`https://${jiraDomainInput}`)
-jiraApiBaseUrl.pathname = '/rest/'
+const auth = {
+  username: jiraUser,
+  password: jiraApiToken,
+}
 
+const headers = {
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+}
+
+/** @param {import('axios').AxiosError} error */
+function onRejected(error) {
+  console.error(
+    `Error ${error.response.status} ${error.response.statusText}`,
+    error.request.path,
+    error.response.data
+  )
+}
+
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/
+const jiraApiBaseUrl = new URL('/rest/api/3/', `https://${jiraDomainInput}`)
 const jiraApi = lib_axios.create({
   baseURL: jiraApiBaseUrl.toString(),
-  headers: {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-  },
-  auth: {
-    username: jiraUser,
-    password: jiraApiToken,
-  },
+  headers,
+  auth,
 })
+jiraApi.interceptors.response.use(null, onRejected)
 
-jiraApi.interceptors.response.use(
-  null,
-  /** @param {import('axios').AxiosError} error */
-  (error) => {
-    console.error(
-      `Error ${error.response.status} ${error.response.statusText}`,
-      error.request.path,
-      error.response.data
-    )
-  }
+// https://docs.atlassian.com/jira-software/REST/7.0.4/
+const jiraAgileApiBaseUrl = new URL(
+  '/rest/agile/1.0/',
+  `https://${jiraDomainInput}`
 )
+const jiraAgileApi = lib_axios.create({
+  baseURL: jiraAgileApiBaseUrl.toString(),
+  headers,
+  auth,
+})
+jiraAgileApi.interceptors.response.use(null, onRejected)
 
 const octokit = github.getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
@@ -42382,7 +42394,7 @@ function normaliseStatusName(name) {
 }
 
 async function getIssues(issuesKeys) {
-  const response = await jiraApi.get('api/3/search', {
+  const response = await jiraApi.get('search/jql', {
     params: {
       maxResults: 100,
       jql: `id in (${issuesKeys.join(',')})`,
@@ -42477,20 +42489,17 @@ async function assignPrToIssues(issueKeys) {
       }
 
       const { data: links } = await jiraApi.get(
-        `api/2/issue/${encodeURIComponent(issueKey)}/remotelink`
+        `issue/${encodeURIComponent(issueKey)}/remotelink`
       )
 
       const alreadyAssigned = links.some(
         (link) => link.object.url === prLinkObject.url
       )
       if (!alreadyAssigned) {
-        await jiraApi.post(
-          `api/2/issue/${encodeURIComponent(issueKey)}/remotelink`,
-          {
-            application: {},
-            object: prLinkObject,
-          }
-        )
+        await jiraApi.post(`issue/${encodeURIComponent(issueKey)}/remotelink`, {
+          application: {},
+          object: prLinkObject,
+        })
       }
     })
   )
@@ -42510,7 +42519,7 @@ function escapeJqlString(str) {
 
 async function getLastIssueInStatusKey(statusName) {
   const statusNameNormalised = normaliseStatusName(statusName)
-  const response = await jiraApi.get('api/3/search', {
+  const response = await jiraApi.get('search/jql', {
     params: {
       maxResults: 1,
       jql: `status="${escapeJqlString(statusNameNormalised)}" ORDER BY Rank DESC`,
@@ -42565,7 +42574,7 @@ async function transitionIssues(issueKeys, newStatusName) {
                 }
 
                 await jiraApi.post(
-                  `api/2/issue/${encodeURIComponent(issueKey)}/transitions`,
+                  `issue/${encodeURIComponent(issueKey)}/transitions`,
                   {
                     transition: {
                       id: newStatusId,
@@ -42583,7 +42592,7 @@ async function transitionIssues(issueKeys, newStatusName) {
 
         // Move all newly transitioned issues to the end of the list
         if (transitionedIssueKeys.length > 0 && lastIssueInStatusKey) {
-          await jiraApi.put('agile/1.0/issue/rank', {
+          await jiraAgileApi.put('issue/rank', {
             issues: transitionedIssueKeys,
             rankAfterIssue: lastIssueInStatusKey,
           })

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42336,7 +42336,7 @@ const pr = payload.pull_request || payload.issue
 
 const githubToken = core.getInput('github-token')
 const githubRequireKeywordPrefix =
-  core.getInput('github-require-keyword-prefix') ?? true
+  core.getInput('github-require-keyword-prefix') !== 'false'
 
 const jiraDomainInput = core.getInput('jira-domain', { required: true })
 const jiraUser = core.getInput('jira-user', { required: true })
@@ -42601,7 +42601,7 @@ async function transitionIssues(issueKeys, newStatusName) {
             rankAfterIssue: lastIssueInStatusKey,
           })
           console.log(
-            `Moved issues issues to the end of column '${newStatusName}':`,
+            `Moved issues to the end of column '${newStatusName}':`,
             ...transitionedIssueKeys
           )
         }

--- a/index.mjs
+++ b/index.mjs
@@ -27,15 +27,17 @@ const jiraStatusPrDraft = core.getInput('jira-status-pr-draft')
 const jiraStatusPrReady = core.getInput('jira-status-pr-ready')
 const jiraStatusPrMerged = core.getInput('jira-status-pr-merged')
 
+const headers = {
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+}
+
 const auth = {
   username: jiraUser,
   password: jiraApiToken,
 }
 
-const headers = {
-  'Accept': 'application/json',
-  'Content-Type': 'application/json',
-}
+const timeoutMs = 10_000
 
 /** @param {import('axios').AxiosError} error */
 function onRejected(error) {
@@ -52,6 +54,7 @@ const jiraApi = axios.create({
   baseURL: jiraApiBaseUrl.toString(),
   headers,
   auth,
+  timeout: timeoutMs,
 })
 jiraApi.interceptors.response.use(null, onRejected)
 
@@ -64,6 +67,7 @@ const jiraAgileApi = axios.create({
   baseURL: jiraAgileApiBaseUrl.toString(),
   headers,
   auth,
+  timeout: timeoutMs,
 })
 jiraAgileApi.interceptors.response.use(null, onRejected)
 

--- a/index.mjs
+++ b/index.mjs
@@ -55,7 +55,7 @@ const jiraApi = axios.create({
 })
 jiraApi.interceptors.response.use(null, onRejected)
 
-// https://docs.atlassian.com/jira-software/REST/7.0.4/
+// https://developer.atlassian.com/cloud/jira/software/rest/
 const jiraAgileApiBaseUrl = new URL(
   '/rest/agile/1.0/',
   `https://${jiraDomainInput}`

--- a/index.mjs
+++ b/index.mjs
@@ -18,7 +18,7 @@ const pr = payload.pull_request || payload.issue
 
 const githubToken = core.getInput('github-token')
 const githubRequireKeywordPrefix =
-  core.getInput('github-require-keyword-prefix') ?? true
+  core.getInput('github-require-keyword-prefix') !== 'false'
 
 const jiraDomainInput = core.getInput('jira-domain', { required: true })
 const jiraUser = core.getInput('jira-user', { required: true })

--- a/index.mjs
+++ b/index.mjs
@@ -283,7 +283,7 @@ async function transitionIssues(issueKeys, newStatusName) {
             rankAfterIssue: lastIssueInStatusKey,
           })
           console.log(
-            `Moved issues issues to the end of column '${newStatusName}':`,
+            `Moved issues to the end of column '${newStatusName}':`,
             ...transitionedIssueKeys
           )
         }

--- a/index.mjs
+++ b/index.mjs
@@ -64,7 +64,7 @@ function normaliseStatusName(name) {
 }
 
 async function getIssues(issuesKeys) {
-  const response = await jiraApi.get('api/2/search', {
+  const response = await jiraApi.get('api/3/search', {
     params: {
       maxResults: 100,
       jql: `id in (${issuesKeys.join(',')})`,
@@ -192,7 +192,7 @@ function escapeJqlString(str) {
 
 async function getLastIssueInStatusKey(statusName) {
   const statusNameNormalised = normaliseStatusName(statusName)
-  const response = await jiraApi.get('api/2/search', {
+  const response = await jiraApi.get('api/3/search', {
     params: {
       maxResults: 1,
       jql: `status="${escapeJqlString(statusNameNormalised)}" ORDER BY Rank DESC`,

--- a/index.mjs
+++ b/index.mjs
@@ -27,33 +27,45 @@ const jiraStatusPrDraft = core.getInput('jira-status-pr-draft')
 const jiraStatusPrReady = core.getInput('jira-status-pr-ready')
 const jiraStatusPrMerged = core.getInput('jira-status-pr-merged')
 
-// https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issues/
-const jiraApiBaseUrl = new URL(`https://${jiraDomainInput}`)
-jiraApiBaseUrl.pathname = '/rest/'
+const auth = {
+  username: jiraUser,
+  password: jiraApiToken,
+}
 
+const headers = {
+  'Accept': 'application/json',
+  'Content-Type': 'application/json',
+}
+
+/** @param {import('axios').AxiosError} error */
+function onRejected(error) {
+  console.error(
+    `Error ${error.response.status} ${error.response.statusText}`,
+    error.request.path,
+    error.response.data
+  )
+}
+
+// https://developer.atlassian.com/cloud/jira/platform/rest/v3/
+const jiraApiBaseUrl = new URL('/rest/api/3/', `https://${jiraDomainInput}`)
 const jiraApi = axios.create({
   baseURL: jiraApiBaseUrl.toString(),
-  headers: {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json',
-  },
-  auth: {
-    username: jiraUser,
-    password: jiraApiToken,
-  },
+  headers,
+  auth,
 })
+jiraApi.interceptors.response.use(null, onRejected)
 
-jiraApi.interceptors.response.use(
-  null,
-  /** @param {import('axios').AxiosError} error */
-  (error) => {
-    console.error(
-      `Error ${error.response.status} ${error.response.statusText}`,
-      error.request.path,
-      error.response.data
-    )
-  }
+// https://docs.atlassian.com/jira-software/REST/7.0.4/
+const jiraAgileApiBaseUrl = new URL(
+  '/rest/agile/1.0/',
+  `https://${jiraDomainInput}`
 )
+const jiraAgileApi = axios.create({
+  baseURL: jiraAgileApiBaseUrl.toString(),
+  headers,
+  auth,
+})
+jiraAgileApi.interceptors.response.use(null, onRejected)
 
 const octokit = github.getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
@@ -64,7 +76,7 @@ function normaliseStatusName(name) {
 }
 
 async function getIssues(issuesKeys) {
-  const response = await jiraApi.get('api/3/search', {
+  const response = await jiraApi.get('search/jql', {
     params: {
       maxResults: 100,
       jql: `id in (${issuesKeys.join(',')})`,
@@ -159,20 +171,17 @@ async function assignPrToIssues(issueKeys) {
       }
 
       const { data: links } = await jiraApi.get(
-        `api/2/issue/${encodeURIComponent(issueKey)}/remotelink`
+        `issue/${encodeURIComponent(issueKey)}/remotelink`
       )
 
       const alreadyAssigned = links.some(
         (link) => link.object.url === prLinkObject.url
       )
       if (!alreadyAssigned) {
-        await jiraApi.post(
-          `api/2/issue/${encodeURIComponent(issueKey)}/remotelink`,
-          {
-            application: {},
-            object: prLinkObject,
-          }
-        )
+        await jiraApi.post(`issue/${encodeURIComponent(issueKey)}/remotelink`, {
+          application: {},
+          object: prLinkObject,
+        })
       }
     })
   )
@@ -192,7 +201,7 @@ function escapeJqlString(str) {
 
 async function getLastIssueInStatusKey(statusName) {
   const statusNameNormalised = normaliseStatusName(statusName)
-  const response = await jiraApi.get('api/3/search', {
+  const response = await jiraApi.get('search/jql', {
     params: {
       maxResults: 1,
       jql: `status="${escapeJqlString(statusNameNormalised)}" ORDER BY Rank DESC`,
@@ -247,7 +256,7 @@ async function transitionIssues(issueKeys, newStatusName) {
                 }
 
                 await jiraApi.post(
-                  `api/2/issue/${encodeURIComponent(issueKey)}/transitions`,
+                  `issue/${encodeURIComponent(issueKey)}/transitions`,
                   {
                     transition: {
                       id: newStatusId,
@@ -265,7 +274,7 @@ async function transitionIssues(issueKeys, newStatusName) {
 
         // Move all newly transitioned issues to the end of the list
         if (transitionedIssueKeys.length > 0 && lastIssueInStatusKey) {
-          await jiraApi.put('agile/1.0/issue/rank', {
+          await jiraAgileApi.put('issue/rank', {
             issues: transitionedIssueKeys,
             rankAfterIssue: lastIssueInStatusKey,
           })

--- a/index.mjs
+++ b/index.mjs
@@ -235,9 +235,9 @@ async function transitionIssues(issueKeys, newStatusName) {
         const lastIssueInStatusKey =
           await getLastIssueInStatusKey(newStatusName)
 
-        const transitionedIssueKeys = await Promise.all(
-          sameStatusIssues
-            .map(async ({ issueKey, availableTransitions }) => {
+        const transitionedIssueKeys = (
+          await Promise.all(
+            sameStatusIssues.map(async ({ issueKey, availableTransitions }) => {
               if (currentStatusName === newStatusNameNormalised) {
                 console.log(
                   'Did not transition',
@@ -269,8 +269,8 @@ async function transitionIssues(issueKeys, newStatusName) {
                 return issueKey
               }
             })
-            .filter(Boolean)
-        )
+          )
+        ).filter(Boolean)
 
         // Move all newly transitioned issues to the end of the list
         if (transitionedIssueKeys.length > 0 && lastIssueInStatusKey) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@remato/trello-integration-action",
+  "name": "@verkstedt/jira-integration-action",
   "version": "6.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@remato/trello-integration-action",
+      "name": "@verkstedt/jira-integration-action",
       "version": "6.1.2",
       "license": "MIT",
       "dependencies": {
@@ -14,7 +14,6 @@
         "axios": "^1.4.0"
       },
       "devDependencies": {
-        "@remato/prettier-config": "^1.0.0",
         "@vercel/ncc": "^0.36.1",
         "@verkstedt/eslint-config-verkstedt": "^10.0.0",
         "eslint": "^8.57.0",
@@ -565,12 +564,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/@remato/prettier-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@remato/prettier-config/-/prettier-config-1.0.0.tgz",
-      "integrity": "sha512-b6E3LmgaMlaGS2EfZXsncifqcLWffmki4tel+oTEpNA+e0X4AD4OLw0yke0El3YriBQaZu9TPKb7eEEbGvxwZg==",
-      "dev": true
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -5537,12 +5530,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
       "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
-      "dev": true
-    },
-    "@remato/prettier-config": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@remato/prettier-config/-/prettier-config-1.0.0.tgz",
-      "integrity": "sha512-b6E3LmgaMlaGS2EfZXsncifqcLWffmki4tel+oTEpNA+e0X4AD4OLw0yke0El3YriBQaZu9TPKb7eEEbGvxwZg==",
       "dev": true
     },
     "@rtsao/scc": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@verkstedt/jira-integration-action",
   "version": "6.1.2",
   "license": "MIT",
-  "description": "GitHub Action to integrate Github pull requests with Trello cards",
+  "description": "GitHub Action to integrate Github pull requests with Jira issues",
   "author": {
     "name": "verkstet GmbH",
     "email": "info@verkstedt.com"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@remato/trello-integration-action",
+  "name": "@verkstedt/jira-integration-action",
   "version": "6.1.2",
   "license": "MIT",
   "description": "GitHub Action to integrate Github pull requests with Trello cards",


### PR DESCRIPTION
> [!TIP]
> When reviewing, don’t look at `dist/index.mjs` — just `index.mjs`.

# Why?

We used v2, which got removed.

Fixes https://verkstedt.atlassian.net/browse/VIP-82

# What?

- **Switch to Jira API v3**
- **Separate jiraAgileApi from jiraApi** — this commit is responsible for most changed lines

Tested on https://github.com/verkstedt/jira-integration-action--test/pull/9

# What else?

- **Update CONTRIBUTING**
- **Filter out undefined new statues after resolving promise** — before this change for jira keys that didn’t have to be transitioned, we ended up with `undefined`, because filtering–out happened before promise resolution.
- Update name and description in package.json
- Set timeout for Jira API requests
- Fix github-require-keyword-prefix input parsing