### PR TITLE
Support multiple statuses in jira-status-* inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ jobs:
           # the issues, so it’s best to create a dedicated user for
           # this sort of things.
           jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
+          # e.g. “In Progress”
           jira-status-pr-draft: ${{ vars.JIRA_STATUS_PR_DRAFT }}
+          # e.g. “In Review|In Dev Review”
           jira-status-pr-ready: ${{ vars.JIRA_STATUS_PR_READY }}
+          # e.g. “QA|In PO Review|Done”
           jira-status-pr-merged: ${{ vars.JIRA_STATUS_PR_MERGED }}
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -18,13 +18,13 @@ inputs:
     description: 'Jira API key, get it on <https://id.atlassian.com/manage-profile/security/api-tokens>. Note that user whose API token is used, will “touch” all of the issues, so it’s best to create a dedicated user for this sort of things.'
     required: true
   jira-status-pr-draft:
-    description: 'Name of the status to transition issue to when PR is in draft'
+    description: 'Name of the status to transition issue to when PR is in draft. If multiple specified (separated by `|`), first matching will be used.'
     required: false
   jira-status-pr-ready:
-    description: 'Name of the status to transition issue to when PR is ready to review'
+    description: 'Name of the status to transition issue to when PR is ready to review. If multiple specified (separated by `|`), first matching will be used.'
     required: false
   jira-status-pr-merged:
-    description: 'Name of the status to transition issue to when PR is merged'
+    description: 'Name of the status to transition issue to when PR is merged. If multiple specified (separated by `|`), first matching will be used.'
     required: false
 runs:
   using: node20

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42588,19 +42588,20 @@ async function transitionIssues(issueKeys, newStatusName) {
 
   const issuesData = await getIssues(issueKeys)
 
-  const issuesByNewStatus = new Map()
+  /** @type {Map<StatusName, Array<IssueData>}>} */
+  const issuesByCurrentStatus = new Map()
   issuesData.forEach((issueData) => {
     const { currentStatusName } = issueData
-    const newStatus = issuesByNewStatus.get(currentStatusName)
+    const newStatus = issuesByCurrentStatus.get(currentStatusName)
     if (newStatus) {
       newStatus.push(issueData)
     } else {
-      issuesByNewStatus.set(currentStatusName, [issueData])
+      issuesByCurrentStatus.set(currentStatusName, [issueData])
     }
   })
 
   await Promise.all(
-    Array.from(issuesByNewStatus.entries()).map(
+    Array.from(issuesByCurrentStatus.entries()).map(
       async ([currentStatusName, sameStatusIssues]) => {
         const lastIssueInStatusKey =
           await getLastIssueInStatusKey(newStatusName)

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42393,10 +42393,37 @@ const octokit = github.getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
 const issueNumber = (payload.pull_request || payload.issue).number
 
+/**
+ * GitHub data
+ *
+ * @typedef {object} PullRequestComment
+ * @property {string} body
+ */
+
+/**
+ * Jira data
+ *
+ * @typedef {string} IssueKey
+ * @typedef {string} StatusName
+ *
+ * @typedef {object} IssueData
+ * @property {string} issueKey
+ * @property {StatusName} currentStatusName
+ * @property {Map<StatusName, number>} availableTransitions
+ */
+
+/**
+ * @param {string} name
+ * @return {StatusName}
+ */
 function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
+/**
+ * @param {Array<IssueKey>} issuesKeys
+ * @return {Promise<Array<IssueData>>}
+ */
 async function getIssues(issuesKeys) {
   const response = await jiraApi.get('search/jql', {
     params: {
@@ -42418,6 +42445,11 @@ async function getIssues(issuesKeys) {
   }))
 }
 
+/**
+ * @param {string} prBody
+ * @param {Array<PullRequestComment>} comments
+ * @return {Array<IssueKey>}
+ */
 function extractResolvedIssueKeys(prBody, comments) {
   const text = [prBody, ...comments.map((comment) => comment.body)].join('\0')
 
@@ -42460,6 +42492,9 @@ function extractResolvedIssueKeys(prBody, comments) {
   )
 }
 
+/**
+ * @return {Promise<Array<PullRequestComment>>}
+ */
 async function getPullRequestComments() {
   console.log('Requesting pull request comments')
 
@@ -42480,6 +42515,10 @@ async function nagToLinkJiraIssue() {
   })
 }
 
+/**
+ * @param {Array<IssueKey>} issueKeys
+ * @return {Promise<void>}
+ */
 async function assignPrToIssues(issueKeys) {
   await Promise.all(
     issueKeys.map(async (issueKey) => {
@@ -42521,6 +42560,10 @@ function escapeJqlString(str) {
   return str.replace(/(["\\])/g, '\\$1')
 }
 
+/**
+ * @param {StatusName} statusName
+ * @return {Promise<IssueKey|undefined>}
+ */
 async function getLastIssueInStatusKey(statusName) {
   const statusNameNormalised = normaliseStatusName(statusName)
   const response = await jiraApi.get('search/jql', {
@@ -42535,6 +42578,11 @@ async function getLastIssueInStatusKey(statusName) {
   return key
 }
 
+/**
+ * @param {Array<IssueKey>} issueKeys
+ * @param {StatusName} newStatusName
+ * @return {Promise<void>}
+ */
 async function transitionIssues(issueKeys, newStatusName) {
   const newStatusNameNormalised = normaliseStatusName(newStatusName)
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42594,6 +42594,12 @@ async function transitionIssues(issueKeys, newStatusNames) {
     const newStatusName = newStatusNamesNormalised.find((statusName) =>
       issueData.availableTransitions.has(statusName)
     )
+    if (!newStatusName) {
+      throw new Error(
+        `Failed to find a valid transition for issue ${issueData.issueKey}. Looked for statuses: ${newStatusNames.join(', ')}. Available transitions: ${Array.from(issueData.availableTransitions.keys()).join(', ')}`
+      )
+    }
+
     if (issuesByNewStatusName.has(newStatusName)) {
       issuesByNewStatusName.get(newStatusName).push(issueData)
     } else {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42580,54 +42580,54 @@ async function getLastIssueInStatusKey(statusName) {
 
 /**
  * @param {Array<IssueKey>} issueKeys
- * @param {StatusName} newStatusName
+ * @param {Array<StatusName>} newStatusNames
  * @return {Promise<void>}
  */
-async function transitionIssues(issueKeys, newStatusName) {
-  const newStatusNameNormalised = normaliseStatusName(newStatusName)
+async function transitionIssues(issueKeys, newStatusNames) {
+  const newStatusNamesNormalised = newStatusNames.map(normaliseStatusName)
 
   const issuesData = await getIssues(issueKeys)
 
   /** @type {Map<StatusName, Array<IssueData>}>} */
-  const issuesByCurrentStatus = new Map()
+  const issuesByNewStatusName = new Map()
   issuesData.forEach((issueData) => {
-    const { currentStatusName } = issueData
-    const newStatus = issuesByCurrentStatus.get(currentStatusName)
-    if (newStatus) {
-      newStatus.push(issueData)
+    const newStatusName = newStatusNamesNormalised.find((statusName) =>
+      issueData.availableTransitions.has(statusName)
+    )
+    if (issuesByNewStatusName.has(newStatusName)) {
+      issuesByNewStatusName.get(newStatusName).push(issueData)
     } else {
-      issuesByCurrentStatus.set(currentStatusName, [issueData])
+      issuesByNewStatusName.set(newStatusName, [issueData])
     }
   })
 
   await Promise.all(
-    Array.from(issuesByCurrentStatus.entries()).map(
-      async ([currentStatusName, sameStatusIssues]) => {
+    Array.from(issuesByNewStatusName.entries()).map(
+      async ([newStatusName, issues]) => {
         const lastIssueInStatusKey =
           await getLastIssueInStatusKey(newStatusName)
 
         const transitionedIssueKeys = (
           await Promise.all(
-            sameStatusIssues.map(async ({ issueKey, availableTransitions }) => {
-              if (currentStatusName === newStatusNameNormalised) {
+            issues.map(async (issue) => {
+              if (issue.currentStatusName === newStatusName) {
                 console.log(
                   'Did not transition',
-                  issueKey,
+                  issue.issueKey,
                   '— already in',
                   newStatusName
                 )
               } else {
-                const newStatusId = availableTransitions.get(
-                  newStatusNameNormalised
-                )
+                const newStatusId =
+                  issue.availableTransitions.get(newStatusName)
                 if (newStatusId == null) {
                   throw new Error(
-                    `List name “${newStatusName}” not found in JIRA. Available statuses: ${Array.from(availableTransitions.keys()).join(', ')}`
+                    `List name “${newStatusName}” not found in JIRA. Available statuses: ${Array.from(issue.availableTransitions.keys()).join(', ')}`
                   )
                 }
 
                 await jiraApi.post(
-                  `issue/${encodeURIComponent(issueKey)}/transitions`,
+                  `issue/${encodeURIComponent(issue.issueKey)}/transitions`,
                   {
                     transition: {
                       id: newStatusId,
@@ -42635,9 +42635,9 @@ async function transitionIssues(issueKeys, newStatusName) {
                   }
                 )
 
-                console.log('Transitioned', issueKey, 'to', newStatusName)
+                console.log('Transitioned', issue.issueKey, 'to', newStatusName)
 
-                return issueKey
+                return issue.issueKey
               }
             })
           )
@@ -42695,7 +42695,7 @@ async function main() {
           'No draft PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraStatusPrDraft)
+        await transitionIssues(issueIds, jiraStatusPrDraft.split('|'))
       }
     } else if (pr.state === 'open' && !isDraft) {
       if (!jiraStatusPrReady) {
@@ -42703,7 +42703,7 @@ async function main() {
           'No ready PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraStatusPrReady)
+        await transitionIssues(issueIds, jiraStatusPrReady.split('|'))
       }
     } else if (pr.state === 'closed') {
       if (!jiraStatusPrMerged) {
@@ -42711,7 +42711,7 @@ async function main() {
           'No merged PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraStatusPrMerged)
+        await transitionIssues(issueIds, jiraStatusPrMerged.split('|'))
       }
     } else {
       console.log(

--- a/index.mjs
+++ b/index.mjs
@@ -276,6 +276,12 @@ async function transitionIssues(issueKeys, newStatusNames) {
     const newStatusName = newStatusNamesNormalised.find((statusName) =>
       issueData.availableTransitions.has(statusName)
     )
+    if (!newStatusName) {
+      throw new Error(
+        `Failed to find a valid transition for issue ${issueData.issueKey}. Looked for statuses: ${newStatusNames.join(', ')}. Available transitions: ${Array.from(issueData.availableTransitions.keys()).join(', ')}`
+      )
+    }
+
     if (issuesByNewStatusName.has(newStatusName)) {
       issuesByNewStatusName.get(newStatusName).push(issueData)
     } else {

--- a/index.mjs
+++ b/index.mjs
@@ -75,10 +75,37 @@ const octokit = github.getOctokit(githubToken)
 const repoOwner = (payload.organization || payload.repository.owner).login
 const issueNumber = (payload.pull_request || payload.issue).number
 
+/**
+ * GitHub data
+ *
+ * @typedef {object} PullRequestComment
+ * @property {string} body
+ */
+
+/**
+ * Jira data
+ *
+ * @typedef {string} IssueKey
+ * @typedef {string} StatusName
+ *
+ * @typedef {object} IssueData
+ * @property {string} issueKey
+ * @property {StatusName} currentStatusName
+ * @property {Map<StatusName, number>} availableTransitions
+ */
+
+/**
+ * @param {string} name
+ * @return {StatusName}
+ */
 function normaliseStatusName(name) {
   return name.trim().toLowerCase().replace(/\s+/g, ' ')
 }
 
+/**
+ * @param {Array<IssueKey>} issuesKeys
+ * @return {Promise<Array<IssueData>>}
+ */
 async function getIssues(issuesKeys) {
   const response = await jiraApi.get('search/jql', {
     params: {
@@ -100,6 +127,11 @@ async function getIssues(issuesKeys) {
   }))
 }
 
+/**
+ * @param {string} prBody
+ * @param {Array<PullRequestComment>} comments
+ * @return {Array<IssueKey>}
+ */
 function extractResolvedIssueKeys(prBody, comments) {
   const text = [prBody, ...comments.map((comment) => comment.body)].join('\0')
 
@@ -142,6 +174,9 @@ function extractResolvedIssueKeys(prBody, comments) {
   )
 }
 
+/**
+ * @return {Promise<Array<PullRequestComment>>}
+ */
 async function getPullRequestComments() {
   console.log('Requesting pull request comments')
 
@@ -162,6 +197,10 @@ async function nagToLinkJiraIssue() {
   })
 }
 
+/**
+ * @param {Array<IssueKey>} issueKeys
+ * @return {Promise<void>}
+ */
 async function assignPrToIssues(issueKeys) {
   await Promise.all(
     issueKeys.map(async (issueKey) => {
@@ -203,6 +242,10 @@ function escapeJqlString(str) {
   return str.replace(/(["\\])/g, '\\$1')
 }
 
+/**
+ * @param {StatusName} statusName
+ * @return {Promise<IssueKey|undefined>}
+ */
 async function getLastIssueInStatusKey(statusName) {
   const statusNameNormalised = normaliseStatusName(statusName)
   const response = await jiraApi.get('search/jql', {
@@ -217,11 +260,17 @@ async function getLastIssueInStatusKey(statusName) {
   return key
 }
 
+/**
+ * @param {Array<IssueKey>} issueKeys
+ * @param {StatusName} newStatusName
+ * @return {Promise<void>}
+ */
 async function transitionIssues(issueKeys, newStatusName) {
   const newStatusNameNormalised = normaliseStatusName(newStatusName)
 
   const issuesData = await getIssues(issueKeys)
 
+  /** @type {Map<string, Array<IssueData>}>} */
   const issuesByNewStatus = new Map()
   issuesData.forEach((issueData) => {
     const { currentStatusName } = issueData

--- a/index.mjs
+++ b/index.mjs
@@ -262,54 +262,54 @@ async function getLastIssueInStatusKey(statusName) {
 
 /**
  * @param {Array<IssueKey>} issueKeys
- * @param {StatusName} newStatusName
+ * @param {Array<StatusName>} newStatusNames
  * @return {Promise<void>}
  */
-async function transitionIssues(issueKeys, newStatusName) {
-  const newStatusNameNormalised = normaliseStatusName(newStatusName)
+async function transitionIssues(issueKeys, newStatusNames) {
+  const newStatusNamesNormalised = newStatusNames.map(normaliseStatusName)
 
   const issuesData = await getIssues(issueKeys)
 
   /** @type {Map<StatusName, Array<IssueData>}>} */
-  const issuesByCurrentStatus = new Map()
+  const issuesByNewStatusName = new Map()
   issuesData.forEach((issueData) => {
-    const { currentStatusName } = issueData
-    const newStatus = issuesByCurrentStatus.get(currentStatusName)
-    if (newStatus) {
-      newStatus.push(issueData)
+    const newStatusName = newStatusNamesNormalised.find((statusName) =>
+      issueData.availableTransitions.has(statusName)
+    )
+    if (issuesByNewStatusName.has(newStatusName)) {
+      issuesByNewStatusName.get(newStatusName).push(issueData)
     } else {
-      issuesByCurrentStatus.set(currentStatusName, [issueData])
+      issuesByNewStatusName.set(newStatusName, [issueData])
     }
   })
 
   await Promise.all(
-    Array.from(issuesByCurrentStatus.entries()).map(
-      async ([currentStatusName, sameStatusIssues]) => {
+    Array.from(issuesByNewStatusName.entries()).map(
+      async ([newStatusName, issues]) => {
         const lastIssueInStatusKey =
           await getLastIssueInStatusKey(newStatusName)
 
         const transitionedIssueKeys = (
           await Promise.all(
-            sameStatusIssues.map(async ({ issueKey, availableTransitions }) => {
-              if (currentStatusName === newStatusNameNormalised) {
+            issues.map(async (issue) => {
+              if (issue.currentStatusName === newStatusName) {
                 console.log(
                   'Did not transition',
-                  issueKey,
+                  issue.issueKey,
                   '— already in',
                   newStatusName
                 )
               } else {
-                const newStatusId = availableTransitions.get(
-                  newStatusNameNormalised
-                )
+                const newStatusId =
+                  issue.availableTransitions.get(newStatusName)
                 if (newStatusId == null) {
                   throw new Error(
-                    `List name “${newStatusName}” not found in JIRA. Available statuses: ${Array.from(availableTransitions.keys()).join(', ')}`
+                    `List name “${newStatusName}” not found in JIRA. Available statuses: ${Array.from(issue.availableTransitions.keys()).join(', ')}`
                   )
                 }
 
                 await jiraApi.post(
-                  `issue/${encodeURIComponent(issueKey)}/transitions`,
+                  `issue/${encodeURIComponent(issue.issueKey)}/transitions`,
                   {
                     transition: {
                       id: newStatusId,
@@ -317,9 +317,9 @@ async function transitionIssues(issueKeys, newStatusName) {
                   }
                 )
 
-                console.log('Transitioned', issueKey, 'to', newStatusName)
+                console.log('Transitioned', issue.issueKey, 'to', newStatusName)
 
-                return issueKey
+                return issue.issueKey
               }
             })
           )
@@ -377,7 +377,7 @@ async function main() {
           'No draft PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraStatusPrDraft)
+        await transitionIssues(issueIds, jiraStatusPrDraft.split('|'))
       }
     } else if (pr.state === 'open' && !isDraft) {
       if (!jiraStatusPrReady) {
@@ -385,7 +385,7 @@ async function main() {
           'No ready PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraStatusPrReady)
+        await transitionIssues(issueIds, jiraStatusPrReady.split('|'))
       }
     } else if (pr.state === 'closed') {
       if (!jiraStatusPrMerged) {
@@ -393,7 +393,7 @@ async function main() {
           'No merged PR status name provided, skipping transitioning issues'
         )
       } else {
-        await transitionIssues(issueIds, jiraStatusPrMerged)
+        await transitionIssues(issueIds, jiraStatusPrMerged.split('|'))
       }
     } else {
       console.log(

--- a/index.mjs
+++ b/index.mjs
@@ -270,20 +270,20 @@ async function transitionIssues(issueKeys, newStatusName) {
 
   const issuesData = await getIssues(issueKeys)
 
-  /** @type {Map<string, Array<IssueData>}>} */
-  const issuesByNewStatus = new Map()
+  /** @type {Map<StatusName, Array<IssueData>}>} */
+  const issuesByCurrentStatus = new Map()
   issuesData.forEach((issueData) => {
     const { currentStatusName } = issueData
-    const newStatus = issuesByNewStatus.get(currentStatusName)
+    const newStatus = issuesByCurrentStatus.get(currentStatusName)
     if (newStatus) {
       newStatus.push(issueData)
     } else {
-      issuesByNewStatus.set(currentStatusName, [issueData])
+      issuesByCurrentStatus.set(currentStatusName, [issueData])
     }
   })
 
   await Promise.all(
-    Array.from(issuesByNewStatus.entries()).map(
+    Array.from(issuesByCurrentStatus.entries()).map(
       async ([currentStatusName, sameStatusIssues]) => {
         const lastIssueInStatusKey =
           await getLastIssueInStatusKey(newStatusName)


### PR DESCRIPTION
# Why?

Closes https://verkstedt.atlassian.net/browse/VIP-79

Different boards use different status column names, so we had github vars set on org level, but often times had to overwrite them for each repo. With this change we’ll be able to set a list of statuses to match.

# What?

- `Types in JSDoc`
- `Support multiple status names in jira-status-* inputs`


# Tested

Tested on https://github.com/verkstedt/jira-integration-action--test/pull/10

# TODO After this gets merged

- [x] Update vars at org level

  ```
  JIRA_STATUS_PR_DRAFT=In Progress|Doing|In Arbeit
  JIRA_STATUS_PR_READY=In Dev Review|Dev QA (PR Review)|PR Review|In Review|Review|In Progress|Doing|In Arbeit
  JIRA_STATUS_PR_MERGED=In PO review|PO QA|QA|Done|Fertig
  ```