### PR TITLE
feat: Improve nag comment when no Jira issue linked

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42726,7 +42726,7 @@ var github_namespaceObject = /*#__PURE__*/__nccwpck_require__.t(github, 2);
 
 const {
   context,
-  context: { payload, repo },
+  context: { payload },
 } = github_namespaceObject
 const pr = payload.pull_request || payload.issue
 
@@ -42841,6 +42841,18 @@ async function getIssues(issuesKeys) {
   }))
 }
 
+const keywords = [
+  'closes',
+  'close',
+  'closed',
+  'fix',
+  'fixes',
+  'fixed',
+  'resolve',
+  'resolves',
+  'resolved',
+]
+
 /**
  * @param {string} prBody
  * @param {Array<PullRequestComment>} comments
@@ -42849,17 +42861,6 @@ async function getIssues(issuesKeys) {
 function extractResolvedIssueKeys(prBody, comments) {
   const text = [prBody, ...comments.map((comment) => comment.body)].join('\0')
 
-  const keywords = [
-    'close',
-    'closes',
-    'closed',
-    'fix',
-    'fixes',
-    'fixed',
-    'resolve',
-    'resolves',
-    'resolved',
-  ]
   const keywordsRegExp = githubRequireKeywordPrefix
     ? `(?:${keywords.join('|')})\\s+`
     : ''
@@ -42894,21 +42895,48 @@ function extractResolvedIssueKeys(prBody, comments) {
 async function getPullRequestComments() {
   core.info('Requesting pull request comments')
 
-  const response = await octokit.rest.issues.listComments({
+  return octokit.paginate(octokit.rest.issues.listComments, {
     owner: repoOwner,
     repo: payload.repository.name,
     issue_number: issueNumber,
+    per_page: 100,
   })
-  return response.data
 }
 
-async function nagToLinkJiraIssue() {
-  await octokit.rest.issues.createComment({
-    issue_number: pr.number,
-    owner: repo.owner,
-    repo: repo.repo,
-    body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
-  })
+async function postTipCommentLinkJiraIssue(comments) {
+  if (
+    // Only post a comment, if acting upon an event that could’ve
+    // changed PR body
+    ['pull_request', 'pull_request_target'].includes(context.eventName) &&
+    ['opened', 'edited'].includes(payload.action)
+  ) {
+    try {
+      const tipCommentMarker = '<!-- JIRA_INTEGRATION_NAG -->'
+
+      const alreadyCommented = comments.some((comment) =>
+        comment.body?.includes(tipCommentMarker)
+      )
+
+      if (alreadyCommented) {
+        core.info('No issues found, but tip comment already present.')
+      } else {
+        core.info('No issues found — posting a tip comment.')
+
+        const keyword =
+          keywords[0].slice(0, 1).toUpperCase() + keywords[0].slice(1)
+        const body = `${tipCommentMarker}\n> [!TIP]\n> Include “${keyword} <var>JIRA_ISSUE_URL</var>” in the PR body to associate it with an issue.`
+
+        await octokit.rest.issues.createComment({
+          issue_number: pr.number,
+          owner: repoOwner,
+          repo: payload.repository.name,
+          body,
+        })
+      }
+    } catch (error) {
+      core.error(`Failed to post tip comment: ${error}`)
+    }
+  }
 }
 
 /**
@@ -43057,15 +43085,9 @@ async function main() {
     const issueIds = extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
-      if (
-        context.eventName === 'pull_request' &&
-        payload.action === 'opened' &&
-        !['main', 'production'].includes(pr.head.ref)
-      ) {
-        void nagToLinkJiraIssue()
-      }
-
       core.info('Could not find issue IDs')
+      // Only post a tip comment when the PR body could have changed
+      await postTipCommentLinkJiraIssue(comments)
       return
     }
     core.info('Found issue IDs:', issueIds.join(', '))

--- a/index.mjs
+++ b/index.mjs
@@ -12,7 +12,7 @@ import * as github from '@actions/github'
 
 const {
   context,
-  context: { payload, repo },
+  context: { payload },
 } = github
 const pr = payload.pull_request || payload.issue
 
@@ -127,6 +127,18 @@ async function getIssues(issuesKeys) {
   }))
 }
 
+const keywords = [
+  'closes',
+  'close',
+  'closed',
+  'fix',
+  'fixes',
+  'fixed',
+  'resolve',
+  'resolves',
+  'resolved',
+]
+
 /**
  * @param {string} prBody
  * @param {Array<PullRequestComment>} comments
@@ -135,17 +147,6 @@ async function getIssues(issuesKeys) {
 function extractResolvedIssueKeys(prBody, comments) {
   const text = [prBody, ...comments.map((comment) => comment.body)].join('\0')
 
-  const keywords = [
-    'close',
-    'closes',
-    'closed',
-    'fix',
-    'fixes',
-    'fixed',
-    'resolve',
-    'resolves',
-    'resolved',
-  ]
   const keywordsRegExp = githubRequireKeywordPrefix
     ? `(?:${keywords.join('|')})\\s+`
     : ''
@@ -180,21 +181,48 @@ function extractResolvedIssueKeys(prBody, comments) {
 async function getPullRequestComments() {
   core.info('Requesting pull request comments')
 
-  const response = await octokit.rest.issues.listComments({
+  return octokit.paginate(octokit.rest.issues.listComments, {
     owner: repoOwner,
     repo: payload.repository.name,
     issue_number: issueNumber,
+    per_page: 100,
   })
-  return response.data
 }
 
-async function nagToLinkJiraIssue() {
-  await octokit.rest.issues.createComment({
-    issue_number: pr.number,
-    owner: repo.owner,
-    repo: repo.repo,
-    body: `@${context.actor} Please add Jira issue URL to the PR description (proceeded with “Closes” or “Fixes”) — it will make issues move when PR status changes.\n`,
-  })
+async function postTipCommentLinkJiraIssue(comments) {
+  if (
+    // Only post a comment, if acting upon an event that could’ve
+    // changed PR body
+    ['pull_request', 'pull_request_target'].includes(context.eventName) &&
+    ['opened', 'edited'].includes(payload.action)
+  ) {
+    try {
+      const tipCommentMarker = '<!-- JIRA_INTEGRATION_NAG -->'
+
+      const alreadyCommented = comments.some((comment) =>
+        comment.body?.includes(tipCommentMarker)
+      )
+
+      if (alreadyCommented) {
+        core.info('No issues found, but tip comment already present.')
+      } else {
+        core.info('No issues found — posting a tip comment.')
+
+        const keyword =
+          keywords[0].slice(0, 1).toUpperCase() + keywords[0].slice(1)
+        const body = `${tipCommentMarker}\n> [!TIP]\n> Include “${keyword} <var>JIRA_ISSUE_URL</var>” in the PR body to associate it with an issue.`
+
+        await octokit.rest.issues.createComment({
+          issue_number: pr.number,
+          owner: repoOwner,
+          repo: payload.repository.name,
+          body,
+        })
+      }
+    } catch (error) {
+      core.error(`Failed to post tip comment: ${error}`)
+    }
+  }
 }
 
 /**
@@ -343,15 +371,9 @@ async function main() {
     const issueIds = extractResolvedIssueKeys(pr.body, comments)
 
     if (!issueIds.length) {
-      if (
-        context.eventName === 'pull_request' &&
-        payload.action === 'opened' &&
-        !['main', 'production'].includes(pr.head.ref)
-      ) {
-        void nagToLinkJiraIssue()
-      }
-
       core.info('Could not find issue IDs')
+      // Only post a tip comment when the PR body could have changed
+      await postTipCommentLinkJiraIssue(comments)
       return
     }
     core.info('Found issue IDs:', issueIds.join(', '))

--- a/package-lock.json
+++ b/package-lock.json
@@ -190,7 +190,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -213,7 +212,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -472,7 +470,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -685,7 +682,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1604,7 +1600,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -1758,7 +1753,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
       "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -1812,7 +1806,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -1888,7 +1881,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.2.tgz",
       "integrity": "sha512-Rbj2R9zwP2GYNcIak4xoAMV57hrBh3hTaR0k7hVjwCQgryE/pw5px4b13EYjduOI0hfXyZhwBxaGpOTbWSGzKQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -1921,7 +1913,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -3743,7 +3734,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3796,7 +3786,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -3834,7 +3823,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4459,7 +4447,6 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.1",
         "@csstools/css-tokenizer": "^3.0.1",
@@ -5360,15 +5347,13 @@
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.1.tgz",
       "integrity": "sha512-lSquqZCHxDfuTg/Sk2hiS0mcSFCEBuj49JfzPHJogDBT0mGCyY5A1AQzBWngitrp7i1/HAZpIgzF/VjhOEIJIg==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "@csstools/css-tokenizer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.1.tgz",
       "integrity": "sha512-UBqaiu7kU0lfvaP982/o3khfXccVlHPWp0/vwwiIgDF0GmqqqxoiXC/6FCjlS9u92f7CoEz6nXKQnrn1kIAkOw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "@csstools/media-query-list-parser": {
       "version": "3.0.1",
@@ -5531,7 +5516,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
       "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
-      "peer": true,
       "requires": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -5702,8 +5686,7 @@
       "version": "8.12.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
       "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -6387,7 +6370,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
       "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6506,7 +6488,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.30.0.tgz",
       "integrity": "sha512-/mHNE9jINJfiD2EKkg1BKyPyUk4zdnT54YgbOgfjSakWT5oyX/qQLVNTkehyfpcMxZXMy1zyonZ2v7hZTX43Yw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -6553,7 +6534,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -6597,7 +6577,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.35.2.tgz",
       "integrity": "sha512-Rbj2R9zwP2GYNcIak4xoAMV57hrBh3hTaR0k7hVjwCQgryE/pw5px4b13EYjduOI0hfXyZhwBxaGpOTbWSGzKQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -6646,7 +6625,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
-      "peer": true,
       "requires": {}
     },
     "eslint-scope": {
@@ -7885,7 +7863,6 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
       "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "dev": true,
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7916,7 +7893,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
-      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -7945,8 +7921,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -8363,7 +8338,6 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-16.9.0.tgz",
       "integrity": "sha512-31Nm3WjxGOBGpQqF43o3wO9L5AC36TPIe6030Lnm13H3vDMTcS21DrLh69bMX+DBilKqMMVLian4iG6ybBoNRQ==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@csstools/css-parser-algorithms": "^3.0.1",
         "@csstools/css-tokenizer": "^3.0.1",


### PR DESCRIPTION
# Why?

Making sure people don’t forget to associate PRs with jira issues.

# What?

When a PR is opened or edited without a Jira issue URL in the body, post a tip comment guiding the author to add one.

This logic already existed, but was broken.

## Checklist

- [x] Ran `prettier -w .`
- [x] Ran `npm run build`

---

```
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Reviewed-by: Claude Sonnet 4.6 <noreply@anthropic.com>
Reviewed-by: codex gpt-5.5 <codex@openai.com>
Reviewed-by: CodeRabbit 0.5.0 <noreply@coderabbit.ai>
```